### PR TITLE
fix: display link targets inline to prevent layout shift in link navigator

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -707,14 +707,13 @@ fn render_link_picker(frame: &mut Frame, app: &App, area: Rect) {
                         .fg(theme.modal_selected_fg())
                         .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
                 ),
+                Span::styled(
+                    format!(" → {}", target_str),
+                    Style::default()
+                        .fg(theme.modal_description())
+                        .add_modifier(Modifier::BOLD),
+                ),
             ]));
-            // Show target on next line when selected
-            lines.push(Line::from(vec![Span::styled(
-                format!("  → {}", target_str),
-                Style::default()
-                    .fg(theme.modal_description())
-                    .add_modifier(Modifier::ITALIC),
-            )]));
         } else {
             lines.push(Line::from(vec![
                 Span::styled("  ", Style::default()),


### PR DESCRIPTION
A minor UI change.

Previously, when cycling through links with Tab, the target would shift from being inline on the right to appearing on a separate line below, then back to the right. This caused the whole list to jump around, making it harder to follow.

With this change, targets are always visible inline (e.g., `[1] Link Text → target`), so the layout stays stable as you navigate.

**Before**:

https://github.com/user-attachments/assets/fd6502d4-0a77-4ad0-9a52-65ad80cb6779

**After**:

https://github.com/user-attachments/assets/d5858e82-2797-4b29-9854-d342920c327c



