### PR TITLE
Fix content panes overlapping status bar

### DIFF
--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -21,8 +21,12 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     let area = frame.area();
 
-    // Create main layout with title bar and content
-    let main_chunks = Layout::vertical([Constraint::Length(2), Constraint::Min(0)]).split(area);
+    // Create main layout with title bar, content area, and status bar
+    let main_chunks = Layout::vertical([
+        Constraint::Length(2),  // Title bar
+        Constraint::Min(0),     // Content area
+        Constraint::Length(1),  // Status bar
+    ]).split(area);
 
     // Render title bar
     render_title_bar(frame, app, main_chunks[0]);
@@ -51,13 +55,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     // Render status bar at bottom
-    let status_area = Rect {
-        x: area.x,
-        y: area.height.saturating_sub(1),
-        width: area.width,
-        height: 1,
-    };
-    render_status_bar(frame, app, status_area);
+    render_status_bar(frame, app, main_chunks[2]);
 
     // Render help popup if shown
     if app.show_help {


### PR DESCRIPTION
## Problem
Content panes (outline and content) were extending all the way to the bottom of the terminal, with the status bar manually positioned on top. This caused pane borders to render behind the status bar text.

## Solution
Changed the vertical layout from a 2-section split to a proper 3-section split:
- Title bar: `Constraint::Length(2)`
- Content area: `Constraint::Min(0)`
- Status bar: `Constraint::Length(1)`

This ensures content panes stop cleanly before the status bar begins.

**Before**:
![Screenshot 2025-12-02 at 5 17 20 PM](https://github.com/user-attachments/assets/dd43f7ac-ba86-4138-b90b-83de15b4b812)

**After**:
![Screenshot 2025-12-02 at 5 17 44 PM](https://github.com/user-attachments/assets/61f6a738-464f-422c-9408-cbfb87b39419)
