### PR TITLE
add support for custom syntect themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,30 @@ search_current_fg = "Black"
 
 </details>
 
+### Custom Code Blocks Theme
+
+Customize syntax highlighting in code blocks using Sublime Text `.tmTheme` files.
+
+```toml
+[ui]
+code_theme = "base16-ocean.dark"  # Default theme
+```
+
+**Built-in themes:** `base16-ocean.dark`, `base16-ocean.light`, `base16-eighties.dark`, `base16-mocha.dark`, `InspiredGitHub`, `Solarized (dark)`, `Solarized (light)`
+
+**Using custom themes:**
+
+1. Create the `code-themes` directory next to your `config.toml file`
+
+2. Add your `.tmTheme` files to the directory
+
+3. Reference the theme by name (filename without extension):
+
+   ```toml
+   [ui]
+   code_theme = "MyCustomTheme"
+   ```
+
 ### CLI Overrides
 
 Override settings for a single session:

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
+    #[serde(skip)]
+    pub path: Option<PathBuf>,
+
     #[serde(default)]
     pub ui: UiConfig,
 
@@ -37,6 +40,9 @@ pub struct Config {
 pub struct UiConfig {
     #[serde(default = "default_theme")]
     pub theme: String,
+
+    #[serde(default = "default_code_theme")]
+    pub code_theme: String,
 
     #[serde(default = "default_outline_width")]
     pub outline_width: u16,
@@ -241,6 +247,7 @@ impl Default for UiConfig {
     fn default() -> Self {
         Self {
             theme: default_theme(),
+            code_theme: default_code_theme(),
             outline_width: default_outline_width(),
             tree_style: default_tree_style(),
         }
@@ -264,6 +271,10 @@ fn default_theme() -> String {
     "OceanDark".to_string()
 }
 
+fn default_code_theme() -> String {
+    "base16-ocean.dark".to_string()
+}
+
 fn default_outline_width() -> u16 {
     30
 }
@@ -284,55 +295,56 @@ impl Config {
     /// - macOS: ~/Library/Application Support/treemd/config.toml
     /// - Linux: ~/.config/treemd/config.toml
     /// - Windows: %APPDATA%/treemd/config.toml
-    pub fn config_path() -> Option<PathBuf> {
+    fn config_path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("treemd").join("config.toml"))
     }
 
-    /// Load config from file, or return default if file doesn't exist
+    /// Resolve the config file path
     /// On macOS, checks ~/.config/treemd first, then falls back to ~/Library/Application Support
-    pub fn load() -> Self {
+    fn resolve_config_path() -> Option<PathBuf> {
         #[cfg(target_os = "macos")]
-        {
-            // Prefer XDG-style path on macOS for CLI tools
-            if let Some(xdg_path) = Self::xdg_config_path()
-                && let Ok(contents) = fs::read_to_string(&xdg_path)
-            {
-                match toml::from_str(&contents) {
-                    Ok(config) => return config,
-                    Err(e) => {
-                        eprintln!(
-                            "warning: failed to parse config {}: {} (using defaults)",
-                            xdg_path.display(),
-                            e
-                        );
-                        return Self::default();
-                    }
-                }
-            }
-        }
+        return Self::xdg_config_path().or_else(Self::config_path);
 
-        // Fall back to platform-specific path
+        #[cfg(not(target_os = "macos"))]
         Self::config_path()
-            .and_then(|path| {
-                let contents = fs::read_to_string(&path).ok()?;
-                match toml::from_str(&contents) {
-                    Ok(config) => Some(config),
-                    Err(e) => {
-                        eprintln!(
-                            "warning: failed to parse config {}: {} (using defaults)",
-                            path.display(),
-                            e
-                        );
-                        None
-                    }
-                }
+    }
+
+    /// Load the configuration file, falling back to `Default` on error.
+    fn load_from_path(path: &PathBuf) -> Self {
+        let Ok(content) = fs::read_to_string(&path) else {
+            return Self::default();
+        };
+
+        match toml::from_str::<Self>(&content) {
+            Ok(config) => return config,
+            Err(e) => {
+                eprintln!(
+                    "warning: failed to parse config {}: {} (using defaults)",
+                    path.display(),
+                    e
+                );
+                return Self::default();
+            }
+        };
+    }
+
+    /// Resolve and load the configuration file, falling back to `Default` if any step fails.
+    pub fn load() -> Self {
+        Self::resolve_config_path()
+            .map(|path| {
+                let mut config = Self::load_from_path(&path);
+                config.path = Some(path.to_owned());
+                config
             })
             .unwrap_or_default()
     }
 
     /// Save config to file
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let path = Self::config_path().ok_or("Could not determine config directory")?;
+        let path = self
+            .path
+            .as_ref()
+            .ok_or("Could not determine config directory")?;
 
         // Create parent directory if it doesn't exist
         if let Some(parent) = path.parent() {
@@ -397,5 +409,14 @@ impl Config {
     /// Check if compact (gapless) tree style is enabled
     pub fn is_compact_tree(&self) -> bool {
         self.ui.tree_style == "compact"
+    }
+
+    /// Get the path of the directory that contains the user's sublime color schemes
+    /// (used for syntax highlighting in code blocks)
+    pub fn code_theme_dir_path(&self) -> Option<PathBuf> {
+        self.path
+            .as_ref()
+            .and_then(|path| path.parent())
+            .map(|parent| parent.join("code-themes"))
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -503,6 +503,11 @@ impl App {
             .with_color_mode(color_mode, current_theme)
             .with_custom_colors(&config.theme, color_mode);
 
+        // Load sublime color scheme directory
+        let code_theme_dir = config.code_theme_dir_path();
+        // Load sublime color scheme name (for code higlighting)
+        let code_theme = config.ui.code_theme.as_str();
+
         // Load outline width from config
         let outline_width = config.ui.outline_width;
 
@@ -531,7 +536,7 @@ impl App {
             show_search: false,
             outline_search_active: false,
             search_query: String::new(),
-            highlighter: SyntaxHighlighter::new(),
+            highlighter: SyntaxHighlighter::new(code_theme, code_theme_dir),
             show_outline: true,
             outline_width,
             config_has_custom_outline_width,

--- a/src/tui/syntax.rs
+++ b/src/tui/syntax.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use syntect::easy::HighlightLines;
@@ -11,10 +13,18 @@ pub struct SyntaxHighlighter {
 }
 
 impl SyntaxHighlighter {
-    pub fn new() -> Self {
+    pub fn new(theme: &str, theme_dir: Option<PathBuf>) -> Self {
         let syntax_set = SyntaxSet::load_defaults_newlines();
-        let theme_set = ThemeSet::load_defaults();
-        let theme = theme_set.themes["base16-ocean.dark"].clone();
+        let mut theme_set = ThemeSet::load_defaults();
+        if let Some(dir) = theme_dir {
+            // Load the user themes if any (silently ignore errors)
+            let _ = theme_set.add_from_folder(dir);
+        }
+
+        let theme = theme_set.themes.get(theme).cloned().unwrap_or_else(|| {
+            // Fallback to the first theme (we know there is one since `load_defaults was used`)
+            theme_set.themes.first_entry().unwrap().get().clone()
+        });
 
         Self { syntax_set, theme }
     }
@@ -80,11 +90,5 @@ impl SyntaxHighlighter {
             .next()
             .unwrap_or("text")
             .to_lowercase()
-    }
-}
-
-impl Default for SyntaxHighlighter {
-    fn default() -> Self {
-        Self::new()
     }
 }


### PR DESCRIPTION
## This PR

​Add support for custom themes for code block syntax highlighting. Pretty straightforward.

​Also fixes a small bug where the config would not necessarily be saved at the same path it was read from on macOS.

## ​Further improvements

​Would you be open to accepting a PR that ports the code from syntect to tree-sitter?

​The main advantage I see is better highlighting, more aligned with most modern tools. Something that really bugs me about the sublime format is that there is no good way to differentiate between types and keywords. But apart from this example, tree-sitter has a way better understanding of the code, which makes it way more powerful (better error tolerance, language injection, ...).

​Another one would be easier integration of code color schemes into the current config system (basically define them directly as TOML). They could also be way slimmer. `.tmTheme` files can quickly become huge.

​And as a bonus, refreshing the code blocks (especially large ones) should be faster with tree-sitter.

​I understand that this change wouldn't be trivial and that it implies more than just "better highlighting", so I prefer to have a discussion before starting any work ;)