### PR TITLE
feat(file-picker): toggle hidden directories with h key

### DIFF
--- a/src/keybindings/action.rs
+++ b/src/keybindings/action.rs
@@ -129,6 +129,8 @@ pub enum Action {
     OpenFilePicker,
     /// Navigate to parent directory in file picker
     ParentDirectory,
+    /// Toggle visibility of hidden (dot) directories in file picker
+    ToggleHiddenDirs,
 
     // === Dialog Actions ===
     /// Confirm action in dialog
@@ -279,6 +281,7 @@ impl Action {
             Action::UndoEdit => "Undo last edit",
             Action::OpenFilePicker => "Open file picker",
             Action::ParentDirectory => "Go to parent directory",
+            Action::ToggleHiddenDirs => "Toggle hidden directories",
 
             // Dialog
             Action::ConfirmAction => "Confirm",
@@ -396,7 +399,8 @@ impl Action {
             | Action::OpenInEditor
             | Action::UndoEdit
             | Action::OpenFilePicker
-            | Action::ParentDirectory => "Files",
+            | Action::ParentDirectory
+            | Action::ToggleHiddenDirs => "Files",
 
             Action::ConfirmAction
             | Action::CancelAction

--- a/src/keybindings/defaults.rs
+++ b/src/keybindings/defaults.rs
@@ -464,6 +464,9 @@ fn add_file_picker_mode(kb: &mut Keybindings) {
     // Search
     bind(kb, FilePicker, "/", LinkSearch);
 
+    // Toggle hidden directories
+    bind(kb, FilePicker, "h", ToggleHiddenDirs);
+
     // Exit
     bind(kb, FilePicker, "Escape", ExitMode);
     bind(kb, FilePicker, "q", Quit);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -350,6 +350,7 @@ pub struct App {
     pub file_search_active: bool,         // Whether search input is active
     pub startup_needs_file_picker: bool,  // True if started without file arg
     pub file_picker_dir: Option<PathBuf>, // Custom directory for file picker
+    pub show_hidden_dirs: bool,           // Whether to show hidden (dot) directories
 
     pub file_history: Vec<FileState>,   // Back navigation stack
     pub file_future: Vec<FileState>,    // Forward navigation stack (for undo back)
@@ -572,6 +573,7 @@ impl App {
             file_search_active: false,
             startup_needs_file_picker: false,
             file_picker_dir: None,
+            show_hidden_dirs: false,
 
             file_history: Vec::new(),
             file_future: Vec::new(),
@@ -1391,6 +1393,10 @@ impl App {
             }
             ParentDirectory => {
                 self.file_picker_parent_dir();
+            }
+            ToggleHiddenDirs => {
+                self.show_hidden_dirs = !self.show_hidden_dirs;
+                self.scan_markdown_files();
             }
 
             // === Dialog Actions ===
@@ -3737,7 +3743,7 @@ impl App {
                     && path
                         .file_name()
                         .and_then(|n| n.to_str())
-                        .map(|name| !name.starts_with('.'))
+                        .map(|name| self.show_hidden_dirs || !name.starts_with('.'))
                         .unwrap_or(false)
                 {
                     dirs.push(path);

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -1002,7 +1002,7 @@ pub fn render_file_picker(frame: &mut Frame, app: &App, area: Rect) {
     let footer_text = if app.file_search_active {
         "Type to filter • Enter: select • Esc: stop search • Backspace: delete"
     } else {
-        "j/k: Navigate • /: Filter • Enter: Open • Backspace: Parent dir • Esc: Cancel"
+        "j/k: Navigate • /: Filter • Enter: Open • Backspace: Parent dir • h: Hidden dirs • Esc: Cancel"
     };
     lines.push(Line::from(vec![Span::styled(
         footer_text,


### PR DESCRIPTION
  Adds `h` in the file picker to toggle dot-prefixed directories
  (e.g. `.obsidian/`, `.config/`). Default unchanged. Rebindable via
  the keybindings config.

  `just ci` passes.

