### PR TITLE
feat(cli): add --normal flag to start TUI in outline navigation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Override settings for a single session:
 treemd --theme Dracula README.md
 treemd --color-mode 256 README.md
 treemd --color-mode rgb README.md
+treemd --normal README.md           # Start in outline navigation mode
 ```
 
 ## Contributing

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -146,6 +146,12 @@ pub struct Cli {
     #[arg(long = "color-mode", value_name = "MODE")]
     pub color_mode: Option<ColorModeArg>,
 
+    /// Start TUI in normal/outline navigation mode
+    ///
+    /// Skip interactive element mode and start with outline navigation.
+    #[arg(long = "normal")]
+    pub normal_mode: bool,
+
     /// Disable image rendering in TUI mode
     ///
     /// Skip all image loading and display. Useful for terminals that don't

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,6 +330,9 @@ fn main() -> Result<()> {
         if needs_file_picker {
             app.startup_needs_file_picker = true;
         }
+        if args.normal_mode {
+            app.force_normal_mode = true;
+        }
         if let Some(dir) = file_picker_dir {
             app.file_picker_dir = Some(dir.canonicalize().unwrap_or(dir));
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -426,6 +426,7 @@ pub struct App {
     // File picker state
     pub file_picker: FilePickerState,
     pub startup_needs_file_picker: bool, // True if started without file arg
+    pub force_normal_mode: bool,          // Start in normal/outline mode
     pub file_picker_dir: Option<PathBuf>, // Custom directory for file picker
     pub show_hidden: bool,               // Whether to show hidden (dot) files and directories
 
@@ -638,6 +639,7 @@ impl App {
             // File picker state
             file_picker: FilePickerState::default(),
             startup_needs_file_picker: false,
+            force_normal_mode: false,
             file_picker_dir: None,
             show_hidden: false,
 
@@ -4638,6 +4640,10 @@ impl App {
 
     /// Enter interactive mode - build element index and enter mode
     pub fn enter_interactive_mode(&mut self) {
+        if self.force_normal_mode {
+            self.force_normal_mode = false;
+            return;
+        }
         // Exit raw source view if active (interactive elements aren't visible in raw mode)
         if self.show_raw_source {
             self.show_raw_source = false;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -84,6 +84,9 @@ pub fn run(terminal: &mut DefaultTerminal, app: App) -> Result<()> {
         app.enter_file_picker();
     }
 
+
+
+
     // Create file watcher for live reload
     let mut file_watcher = watcher::FileWatcher::new().ok();
     if let Some(ref mut watcher) = file_watcher {
@@ -119,6 +122,20 @@ pub fn run(terminal: &mut DefaultTerminal, app: App) -> Result<()> {
             }
 
             needs_redraw = false;
+
+            // After the first render with --normal, drain any buffered
+            // input and reset outline to the first heading.
+            if app.force_normal_mode {
+                while tty::poll_event(Duration::ZERO)? {
+                    let _ = tty::read_event()?;
+                }
+                app.outline_state.select(Some(0));
+                app.content_scroll = 0;
+                app.mode = app::AppMode::Normal;
+                app.force_normal_mode = false;
+                needs_redraw = true;
+                continue;
+            }
         }
 
         // Update file watcher if the current file changed (e.g., via navigation)

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -379,3 +379,26 @@ fn section_with_inline_markdown_in_heading() {
     );
     assert!(!stdout.contains("body-of-next"));
 }
+
+// ------------------------------------------------------------------
+// --normal flag is accepted (TUI mode cannot be tested without a TTY,
+// but we verify the flag parses correctly alongside CLI flags)
+// ------------------------------------------------------------------
+
+#[test]
+fn normal_flag_accepted_with_list() {
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["--normal", "-l", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("# Title"));
+}
+
+#[test]
+fn normal_flag_in_help_output() {
+    let (stdout, _, code) = run(&["--help"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("--normal"),
+        "help should mention --normal flag"
+    );
+}


### PR DESCRIPTION
## Problem

`treemd file.md` always starts in interactive element mode. Users who prefer outline navigation have to press `Esc` every time to switch to normal mode. There is no way to control the startup mode.

```bash
treemd README.md
# TUI opens in interactive mode (status bar: "j/k Navigate | Enter Action | Esc Exit")
# Must press Esc to reach normal outline navigation mode
```

## Solution

Add a `--normal` CLI flag that starts the TUI in outline navigation mode.

```bash
treemd --normal README.md
```

### What the flag does

1. **Guards `enter_interactive_mode`**: the first call is blocked (one shot), keeping the TUI in `AppMode::Normal`. Subsequent `i` keypresses enter interactive mode as usual.
2. **Post-first-render cleanup**: after the initial draw, any buffered input events are drained (zero-timeout poll), the outline cursor is reset to the first heading, content scroll is reset to top, and mode is forced to `Normal` with a redraw. This ensures a clean starting state regardless of what triggered during the first frame.

### Usage with an external file picker

```bash
#!/usr/bin/env sh
f=$(fd -e md | fzf)
[ -n "$f" ] && exec treemd --normal "$f"
```

## Testing

Two new integration tests verify the flag is accepted by the CLI parser and appears in help output.

---

> Note: I used AI (Claude) to research the root cause and develop this fix.