### PR TITLE
fix: disambiguate duplicate-text headings when extracting sections

### DIFF
--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -132,12 +132,31 @@ impl Document {
     /// Extract the content of a section by heading text.
     ///
     /// Uses stored byte offsets for fast, accurate extraction without string searching.
+    /// When the document contains duplicate heading text (e.g. multiple "Input" headings),
+    /// this returns the section for the *first* match. Use [`extract_section_at_offset`]
+    /// to disambiguate by position.
+    ///
+    /// [`extract_section_at_offset`]: Self::extract_section_at_offset
     pub fn extract_section(&self, heading_text: &str) -> Option<String> {
         // Find the heading (O(n) scan of headings list)
         let search = heading_text.to_lowercase();
         let heading_idx = self.heading_text_lc.iter().position(|lc| *lc == search)?;
+        self.extract_section_by_index(heading_idx)
+    }
 
-        let heading = &self.headings[heading_idx];
+    /// Extract the content of the section whose heading starts at the given byte offset.
+    ///
+    /// Unlike [`extract_section`], this disambiguates duplicate heading texts because
+    /// each heading has a unique offset in the source.
+    ///
+    /// [`extract_section`]: Self::extract_section
+    pub fn extract_section_at_offset(&self, offset: usize) -> Option<String> {
+        let heading_idx = self.headings.iter().position(|h| h.offset == offset)?;
+        self.extract_section_by_index(heading_idx)
+    }
+
+    fn extract_section_by_index(&self, heading_idx: usize) -> Option<String> {
+        let heading = self.headings.get(heading_idx)?;
 
         // Start from the heading's stored byte offset
         let start = heading.offset;
@@ -158,7 +177,6 @@ impl Document {
             .map(|h| h.offset)
             .unwrap_or(self.content.len());
 
-        // Extract section content
         Some(self.content[content_start..end].trim().to_string())
     }
 }
@@ -458,6 +476,35 @@ mod tests {
         assert!(section.contains("A1"), "deeper subsection stays in A");
         assert!(section.contains("a1-body"));
         assert!(!section.contains("b-body"));
+    }
+
+    #[test]
+    fn extract_section_at_offset_disambiguates_duplicates() {
+        // Two "### Input" sections with the same text but different content —
+        // looking them up by offset must return the correct one.
+        let content =
+            "## query/1\n\n### Input\nhow many sessions\n\n## query/2\n\n### Input\nwhat tools\n";
+        let q1 = content.find("## query/1").unwrap();
+        let in1 = content.find("### Input").unwrap();
+        let q2 = content.find("## query/2").unwrap();
+        let in2 = content[in1 + 1..].find("### Input").unwrap() + in1 + 1;
+        let d = doc(
+            content,
+            vec![
+                h(2, "query/1", q1),
+                h(3, "Input", in1),
+                h(2, "query/2", q2),
+                h(3, "Input", in2),
+            ],
+        );
+
+        let first = d.extract_section_at_offset(in1).expect("first Input");
+        assert!(first.contains("how many sessions"));
+        assert!(!first.contains("what tools"));
+
+        let second = d.extract_section_at_offset(in2).expect("second Input");
+        assert!(second.contains("what tools"));
+        assert!(!second.contains("how many sessions"));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -536,6 +536,10 @@ pub struct OutlineItem {
     pub text: String,
     pub expanded: bool,
     pub has_children: bool, // Track if this heading has children in the tree
+    /// Byte offset of the heading in `Document::content`. Uniquely identifies
+    /// the heading even when multiple headings share the same text.
+    /// `None` for the synthetic document-overview item.
+    pub offset: Option<usize>,
 }
 
 impl App {
@@ -561,6 +565,7 @@ impl App {
                     text: DOCUMENT_OVERVIEW.to_string(),
                     expanded: true,
                     has_children: !outline_items.is_empty(),
+                    offset: None,
                 },
             );
         }
@@ -2121,6 +2126,7 @@ impl App {
                     text: DOCUMENT_OVERVIEW.to_string(),
                     expanded: true,
                     has_children: !self.outline_items.is_empty(),
+                    offset: None,
                 },
             );
         }
@@ -2146,6 +2152,7 @@ impl App {
                 text: node.heading.text.clone(),
                 expanded,
                 has_children,
+                offset: Some(node.heading.offset),
             });
 
             // Only show children if this node is expanded
@@ -2456,6 +2463,7 @@ impl App {
                         text: DOCUMENT_OVERVIEW.to_string(),
                         expanded: true,
                         has_children: !self.tree.is_empty(),
+                        offset: None,
                     },
                 );
             }
@@ -3498,10 +3506,19 @@ impl App {
             .map(|item| item.text.as_str())
     }
 
+    /// Byte offset of the currently selected heading in `Document::content`.
+    /// `None` if nothing is selected or the selection is the synthetic document overview.
+    pub fn selected_heading_offset(&self) -> Option<usize> {
+        self.outline_state
+            .selected()
+            .and_then(|i| self.outline_items.get(i))
+            .and_then(|item| item.offset)
+    }
+
     /// Get the content for the currently selected section, or the full document if no heading is selected.
     fn current_section_content(&self) -> String {
-        self.selected_heading_text()
-            .and_then(|text| self.document.extract_section(text))
+        self.selected_heading_offset()
+            .and_then(|off| self.document.extract_section_at_offset(off))
             .unwrap_or_else(|| self.document.content.clone())
     }
 
@@ -3516,15 +3533,12 @@ impl App {
             return Some(1); // Return line 1 for document overview
         }
 
-        // Find the heading in the document by text
-        let heading = self
-            .document
-            .headings
-            .iter()
-            .find(|h| h.text == selected_text)?;
+        // Use the outline item's stored offset (uniquely identifies the heading
+        // even when multiple headings share the same text).
+        let heading_offset = self.selected_heading_offset()?;
 
         // Convert byte offset to line number (1-indexed)
-        let offset = heading.offset.min(self.document.content.len());
+        let offset = heading_offset.min(self.document.content.len());
         let before = &self.document.content[..offset];
         let line = before.chars().filter(|&c| c == '\n').count() + 1;
         Some(line as u32)
@@ -3636,8 +3650,11 @@ impl App {
 
     pub fn copy_content(&mut self) {
         // Copy the currently selected section's content
-        if let Some(heading_text) = self.selected_heading_text() {
-            if let Some(section) = self.document.extract_section(heading_text) {
+        if self.selected_heading_text().is_some() {
+            if let Some(section) = self
+                .selected_heading_offset()
+                .and_then(|off| self.document.extract_section_at_offset(off))
+            {
                 // Use persistent clipboard for Linux X11 compatibility
                 if let Some(clipboard) = &mut self.clipboard {
                     match clipboard.set_text(section) {
@@ -5201,11 +5218,7 @@ impl App {
                     .count();
 
                 // Use heading offset to find section start (avoids unreliable string search)
-                let section_start = self
-                    .selected_heading_text()
-                    .and_then(|text| self.document.find_heading(text))
-                    .map(|h| h.offset)
-                    .unwrap_or(0);
+                let section_start = self.selected_heading_offset().unwrap_or(0);
                 let content_before_section =
                     &self.document.content[..section_start.min(self.document.content.len())];
 

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -347,8 +347,8 @@ fn render_content(frame: &mut Frame, app: &mut App, area: Rect) {
     // Get content for selected section and determine title
     let (content_text, title) = if let Some(heading_text) = app.selected_heading_text() {
         let content = app
-            .document
-            .extract_section(heading_text)
+            .selected_heading_offset()
+            .and_then(|off| app.document.extract_section_at_offset(off))
             .unwrap_or_else(|| app.document.content.clone());
 
         // Build title with various indicators


### PR DESCRIPTION
extract_section looked up sections by heading text alone, so any document with repeated headings (e.g. two `### Foo` sections under different parents) would always render, copy, and link to the first match.