### PR TITLE
feat(tui): add toggle for heading markers in outline sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Toggle heading markers in outline** - New `outline_heading_markers` config option, `#` keyboard shortcut, and `:toggle heading markers` palette command to show/hide `#`/`##`/`###` level prefixes in the outline sidebar (default: true)
+
 ## [0.5.11] - 2026-04-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ treemd *.md             # Open file picker with matched files
 | `h` / `l` or `←` / `→` | Collapse/expand heading |
 | `w` | Toggle outline visibility |
 | `[` / `]` | Adjust outline width (20%, 30%, 40%) |
+| `#` | Toggle heading level markers in outline |
 
 </details>
 
@@ -370,9 +371,10 @@ The file is created automatically when you change settings (theme with `t`, outl
 
 ```toml
 [ui]
-theme = "Nord"         # OceanDark, Nord, Dracula, Solarized, Monokai, Gruvbox, TokyoNight, CatppuccinMocha
-outline_width = 30     # 20, 30, or 40
-tree_style = "spaced"  # "spaced" (default) or "compact" (gapless box characters)
+theme = "Nord"                  # OceanDark, Nord, Dracula, Solarized, Monokai, Gruvbox, TokyoNight, CatppuccinMocha
+outline_width = 30              # 20, 30, or 40
+tree_style = "spaced"           # "spaced" (default) or "compact" (gapless box characters)
+outline_heading_markers = true  # Show #/##/### level markers in outline sidebar
 
 [terminal]
 color_mode = "auto"    # "auto", "rgb", or "256"

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,10 @@ pub struct UiConfig {
     /// Tree rendering style: "compact" (default, gapless) or "spaced"
     #[serde(default = "default_tree_style")]
     pub tree_style: String,
+
+    /// Show heading level markers (e.g. ##, ###) in the outline sidebar (default: true)
+    #[serde(default = "default_outline_heading_markers")]
+    pub outline_heading_markers: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -250,12 +254,17 @@ impl Default for UiConfig {
             code_theme: default_code_theme(),
             outline_width: default_outline_width(),
             tree_style: default_tree_style(),
+            outline_heading_markers: default_outline_heading_markers(),
         }
     }
 }
 
 fn default_tree_style() -> String {
     "compact".to_string()
+}
+
+fn default_outline_heading_markers() -> bool {
+    true
 }
 
 impl Default for TerminalConfig {
@@ -479,6 +488,7 @@ mod tests {
         assert_eq!(c.ui.code_theme, "base16-ocean.dark");
         assert_eq!(c.ui.outline_width, 30);
         assert_eq!(c.ui.tree_style, "compact");
+        assert!(c.ui.outline_heading_markers);
         assert_eq!(c.terminal.color_mode, "auto");
         assert!(!c.terminal.warned_terminal_app);
         assert!(c.images.enabled);

--- a/src/keybindings/action.rs
+++ b/src/keybindings/action.rs
@@ -51,6 +51,8 @@ pub enum Action {
     OutlineWidthDecrease,
     /// Toggle filtering outline by open todos
     ToggleTodoFilter,
+    /// Toggle heading level markers (#, ##, ###) in outline
+    ToggleHeadingMarkers,
 
     // === Bookmarks ===
     /// Set bookmark at current position
@@ -235,6 +237,7 @@ impl Action {
             Action::OutlineWidthIncrease => "Increase outline width",
             Action::OutlineWidthDecrease => "Decrease outline width",
             Action::ToggleTodoFilter => "Filter by open todos",
+            Action::ToggleHeadingMarkers => "Toggle heading markers",
 
             // Bookmarks
             Action::SetBookmark => "Set bookmark",
@@ -363,7 +366,8 @@ impl Action {
             | Action::ToggleOutline
             | Action::OutlineWidthIncrease
             | Action::OutlineWidthDecrease
-            | Action::ToggleTodoFilter => "Outline",
+            | Action::ToggleTodoFilter
+            | Action::ToggleHeadingMarkers => "Outline",
 
             Action::SetBookmark | Action::JumpToBookmark => "Bookmarks",
 

--- a/src/keybindings/defaults.rs
+++ b/src/keybindings/defaults.rs
@@ -92,6 +92,7 @@ fn add_normal_mode(kb: &mut Keybindings) {
     bind(kb, Normal, "[", OutlineWidthDecrease);
     bind(kb, Normal, "]", OutlineWidthIncrease);
     bind(kb, Normal, "T", ToggleTodoFilter);
+    bind(kb, Normal, "#", ToggleHeadingMarkers);
 
     // Bookmarks
     bind(kb, Normal, "m", SetBookmark);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -75,6 +75,7 @@ pub enum CommandAction {
     SaveFile, // Save pending edits to file (:w)
     Undo,     // Undo last pending edit
     ToggleOutline,
+    ToggleHeadingMarkers,
     ToggleHelp,
     ToggleRawSource,
     JumpToTop,
@@ -216,6 +217,12 @@ pub const PALETTE_COMMANDS: &[PaletteCommand] = &[
         &["outline", "sidebar"],
         "Show/hide the outline sidebar",
         CommandAction::ToggleOutline,
+    ),
+    PaletteCommand::new(
+        "Toggle heading markers",
+        &["markers", "hashes"],
+        "Show/hide # level markers in outline",
+        CommandAction::ToggleHeadingMarkers,
     ),
     PaletteCommand::new(
         "Toggle help",
@@ -394,7 +401,8 @@ pub struct App {
     pub search_query: String,
     pub highlighter: SyntaxHighlighter,
     pub show_outline: bool,
-    pub outline_width: u16, // Percentage: 20, 30, or 40
+    pub show_heading_markers: bool, // Show # prefixes in outline sidebar
+    pub outline_width: u16,         // Percentage: 20, 30, or 40
     /// Whether the config file had a custom (non-standard) outline width at startup.
     /// Used to protect power users' custom config values from being overwritten.
     /// Standard values are 20, 30, 40; anything else is considered custom.
@@ -615,6 +623,7 @@ impl App {
             search_query: String::new(),
             highlighter: SyntaxHighlighter::new(code_theme, code_theme_dir),
             show_outline: true,
+            show_heading_markers: config.ui.outline_heading_markers,
             outline_width,
             config_has_custom_outline_width,
             bookmark_position: None,
@@ -1339,6 +1348,7 @@ impl App {
             OutlineWidthIncrease => self.cycle_outline_width(true),
             OutlineWidthDecrease => self.cycle_outline_width(false),
             ToggleTodoFilter => self.toggle_todo_filter(),
+            ToggleHeadingMarkers => self.toggle_heading_markers(),
 
             // === Bookmarks ===
             SetBookmark => self.set_bookmark(),
@@ -3169,6 +3179,17 @@ impl App {
         }
     }
 
+    /// Toggle heading level markers (#, ##, ###) in the outline sidebar
+    pub fn toggle_heading_markers(&mut self) {
+        self.show_heading_markers = !self.show_heading_markers;
+        let state = if self.show_heading_markers {
+            "ON"
+        } else {
+            "OFF"
+        };
+        self.set_status_message(&format!("Heading markers: {}", state));
+    }
+
     /// Toggle filtering outline by open todos
     pub fn toggle_todo_filter(&mut self) {
         self.filter_by_todos = !self.filter_by_todos;
@@ -3404,6 +3425,10 @@ impl App {
             }
             CommandAction::ToggleOutline => {
                 self.toggle_outline();
+                false
+            }
+            CommandAction::ToggleHeadingMarkers => {
+                self.toggle_heading_markers();
                 false
             }
             CommandAction::ToggleHelp => {

--- a/src/tui/help_text.rs
+++ b/src/tui/help_text.rs
@@ -201,6 +201,11 @@ pub const HELP_LINES: &[HelpLine] = &[
         &[Next, Previous],
         "Move N items (vim count prefix, e.g., 5j)",
     ),
+    keybinding(
+        Normal,
+        &[ToggleHeadingMarkers],
+        "Toggle heading markers in outline",
+    ),
     keybinding(Normal, &[SetBookmark], "Set bookmark (shows ⚑ indicator)"),
     keybinding(Normal, &[JumpToBookmark], "Jump to bookmarked position"),
     blank(),

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -280,15 +280,17 @@ fn render_outline(frame: &mut Frame, app: &mut App, area: Rect) {
             let color = theme.heading_color(item.level);
             let base_style = Style::default().fg(color);
 
-            // Build prefix (indent + indicators + #'s)
+            // Build prefix (indent + indicators + optional #'s)
             let prefix_text = if item.text == DOCUMENT_OVERVIEW {
                 format!("{}{}{}📄 ", indent, expand_indicator, bookmark_indicator)
-            } else {
+            } else if app.show_heading_markers {
                 let hashes = "#".repeat(item.level);
                 format!(
                     "{}{}{}{} ",
                     indent, expand_indicator, bookmark_indicator, hashes
                 )
+            } else {
+                format!("{}{}{}", indent, expand_indicator, bookmark_indicator)
             };
 
             // Build line with search highlighting using shared utility


### PR DESCRIPTION
# Why

I noticed that the headings in the outline were always explicitly prefixed with the `level` * `#`

I'm not sure if this is a feature you'd want with since the implementation was explicit, but for my own use case I found it easier to view the outline without the prefix - so thought maybe others might want the option.


# Change
Added an option to show/hide the `#` markers. 

By default the behaviour is the same as it used to be (show)

- New `outline_heading_markers` config option 
- `:toggle heading markers` palette command to show/hide `#/##/###`
- `#` keyboard shortcut for the same as above


# Demo
<img width="1522" height="1008" alt="outline" src="https://github.com/user-attachments/assets/e26633f5-1358-452d-94a2-6b8ee9c285aa" />
