### PR TITLE
feat: add -n/--line-numbers flag to append heading line ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-n` / `--line-numbers`** - `--list` and `--tree` can now append each heading's `[start-end]` line range in plain output, so a section can be fetched by line range instead of loaded in full — useful for keeping LLM context small
+
 ## [0.7.0] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Use it to:
 | **Tree visualization** | Hierarchical display with `--tree` |
 | **Section extraction** | Extract by heading name with `-s` |
 | **Smart filtering** | Filter by text or level (`--filter`, `-L`) |
+| **Line ranges** | Append each heading's `[start-end]` line range with `-n` |
 | **Multiple formats** | Plain text or JSON output (`-o json`) |
 | **Statistics** | Count headings by level (`--count`) |
 | **Stdin support** | Pipe markdown content (`cat doc.md \| treemd -q '.h'`) |
@@ -293,6 +294,16 @@ treemd -l -L 2 README.md                # Only ## headings
 treemd --count README.md                # Count by level
 treemd -l -o json README.md             # JSON output
 ```
+
+#### Line ranges
+
+```bash
+treemd -l -n README.md                  # Each heading with its [start-end] line range
+treemd --tree -n README.md              # Same, in tree form
+```
+
+Useful for LLM-driven workflows: read the heading list first, then fetch only
+the line range for the section that matters instead of the whole file.
 
 ### Query Language
 

--- a/skills/treemd/SKILL.md
+++ b/skills/treemd/SKILL.md
@@ -52,7 +52,10 @@ Pinpoint the sections relevant to your goal.
 treemd -l --filter "install" FILE.md        # Fuzzy heading search (case-insensitive)
 treemd -l -L 2 --filter "API" FILE.md      # Narrow by heading level + keyword
 treemd --at-line 150 FILE.md               # "Which heading covers line 150?"
+treemd -l -n FILE.md                       # Each heading with its [start-end] line range
 ```
+
+> **Tip for agents**: `-n` (combine with `-l` or `--tree`) appends a `[start-end]` line range to every heading in plain output — e.g. `## Installation [12-34]`. `start` is the heading's own line; `end` is the last line before the next heading at the same or a shallower level (or the document's last line). This lets you read only the lines for the section you need (e.g. via `Read` with an offset/limit) instead of loading the whole file — much cheaper than parsing `-o json`'s `position.line` for the same information.
 
 ### Step 3: Extract
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -94,6 +94,19 @@ pub struct Cli {
     #[arg(long = "filter", value_name = "PATTERN")]
     pub filter: Option<String>,
 
+    /// Show each heading's line range as `[start-end]` (non-interactive)
+    ///
+    /// Appends the 1-indexed line range to every heading in --list or --tree
+    /// plain output: `start` is the line the heading itself is on, `end` is
+    /// the last line before the next heading at the same or a shallower
+    /// level (or the last line of the document). Lets a downstream reader —
+    /// human or LLM — fetch only the lines for a section of interest instead
+    /// of loading the whole file.
+    ///
+    /// Example: -l -n prints `## Installation [12-34]`
+    #[arg(short = 'n', long = "line-numbers")]
+    pub line_numbers: bool,
+
     /// Show only headings at specific level (1-6)
     ///
     /// Filters headings by their level:

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,11 +432,11 @@ fn handle_cli_mode(args: &Cli, doc: &Document) {
     if args.count {
         print_heading_counts(doc);
     } else if args.tree {
-        print_tree(doc, &args.output, &headings);
+        print_tree(doc, &args.output, &headings, args.line_numbers);
     } else if let Some(ref section_name) = args.section {
         extract_section(doc, section_name);
     } else if args.list {
-        print_headings(&headings, &args.output, doc);
+        print_headings(&headings, &args.output, doc, args.line_numbers);
     }
 }
 
@@ -478,12 +478,23 @@ fn print_heading_at_line(doc: &Document, target_line: usize) {
     }
 }
 
-fn print_headings(headings: &[&parser::Heading], format: &OutputFormat, doc: &Document) {
+fn print_headings(
+    headings: &[&parser::Heading],
+    format: &OutputFormat,
+    doc: &Document,
+    line_numbers: bool,
+) {
     match format {
         OutputFormat::Plain => {
+            let ranges = line_numbers.then(|| doc.heading_line_ranges());
             for heading in headings {
                 let prefix = "#".repeat(heading.level);
-                println!("{} {}", prefix, heading.text);
+                match ranges.as_ref().and_then(|r| r.get(&heading.offset)) {
+                    Some(&(start, end)) => {
+                        println!("{} {} [{}-{}]", prefix, heading.text, start, end)
+                    }
+                    None => println!("{} {}", prefix, heading.text),
+                }
             }
         }
         OutputFormat::Json => {
@@ -500,7 +511,12 @@ fn print_headings(headings: &[&parser::Heading], format: &OutputFormat, doc: &Do
     }
 }
 
-fn print_tree(doc: &Document, format: &OutputFormat, headings: &[&parser::Heading]) {
+fn print_tree(
+    doc: &Document,
+    format: &OutputFormat,
+    headings: &[&parser::Heading],
+    line_numbers: bool,
+) {
     // Build the tree from the (possibly filtered) heading subset so that
     // --tree --filter / --tree --level honor the docstring. When no filter
     // is in play, `headings` is the full list and we get the same tree as
@@ -518,9 +534,14 @@ fn print_tree(doc: &Document, format: &OutputFormat, headings: &[&parser::Headin
 
     match format {
         OutputFormat::Tree | OutputFormat::Plain => {
+            let ranges = line_numbers.then(|| doc.heading_line_ranges());
             for (i, node) in tree.iter().enumerate() {
                 let is_last = i == tree.len() - 1;
-                print!("{}", node.render_box_tree_styled("", is_last, compact));
+                let rendered = match ranges.as_ref() {
+                    Some(ranges) => node.render_box_tree_with_lines("", is_last, compact, ranges),
+                    None => node.render_box_tree_styled("", is_last, compact),
+                };
+                print!("{}", rendered);
             }
         }
         OutputFormat::Json => {

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -3,6 +3,8 @@
 //! This module defines the core data structures for representing
 //! markdown documents and their heading hierarchy.
 
+use std::collections::HashMap;
+
 use serde::Serialize;
 
 /// A markdown document with its content and structure.
@@ -216,6 +218,46 @@ impl Document {
             .map(|h| h.offset)
             .unwrap_or(self.content.len())
     }
+
+    /// Compute the 1-indexed `(start_line, end_line)` for every heading,
+    /// keyed by that heading's byte offset (unique per heading).
+    ///
+    /// `start_line` is the line the heading itself sits on. `end_line` is
+    /// the last line before the next heading at the same or a shallower
+    /// level — the same "subtree" boundary `section_end` uses for byte
+    /// offsets — or the document's last line when no such heading follows.
+    pub fn heading_line_ranges(&self) -> HashMap<usize, (usize, usize)> {
+        let n = self.headings.len();
+
+        // Single sequential pass: count newlines between consecutive heading
+        // offsets rather than re-scanning from the start of the document for
+        // each heading.
+        let mut start_lines = Vec::with_capacity(n);
+        let mut prev_line = 1usize;
+        let mut prev_offset = 0usize;
+        for heading in &self.headings {
+            let line = prev_line
+                + self.content[prev_offset..heading.offset]
+                    .matches('\n')
+                    .count();
+            start_lines.push(line);
+            prev_line = line;
+            prev_offset = heading.offset;
+        }
+
+        let total_lines = self.content.lines().count();
+
+        let mut ranges = HashMap::with_capacity(n);
+        for (idx, heading) in self.headings.iter().enumerate() {
+            let end_line = self.headings[idx + 1..]
+                .iter()
+                .position(|next| next.level <= heading.level)
+                .map(|rel| start_lines[idx + 1 + rel] - 1)
+                .unwrap_or(total_lines);
+            ranges.insert(heading.offset, (start_lines[idx], end_line));
+        }
+        ranges
+    }
 }
 
 impl HeadingNode {
@@ -227,6 +269,28 @@ impl HeadingNode {
 
     /// Render as tree with box-drawing characters, with optional compact style
     pub fn render_box_tree_styled(&self, prefix: &str, is_last: bool, compact: bool) -> String {
+        self.render_box_tree_inner(prefix, is_last, compact, None)
+    }
+
+    /// Render as tree with box-drawing characters, appending each heading's
+    /// `[start-end]` line range (see `Document::heading_line_ranges`).
+    pub fn render_box_tree_with_lines(
+        &self,
+        prefix: &str,
+        is_last: bool,
+        compact: bool,
+        ranges: &HashMap<usize, (usize, usize)>,
+    ) -> String {
+        self.render_box_tree_inner(prefix, is_last, compact, Some(ranges))
+    }
+
+    fn render_box_tree_inner(
+        &self,
+        prefix: &str,
+        is_last: bool,
+        compact: bool,
+        ranges: Option<&HashMap<usize, (usize, usize)>>,
+    ) -> String {
         let mut result = String::new();
 
         let (connector, space, continuation) = if compact {
@@ -246,16 +310,25 @@ impl HeadingNode {
         };
 
         let marker = "#".repeat(self.heading.level);
+        let line_suffix = ranges
+            .and_then(|r| r.get(&self.heading.offset))
+            .map(|&(start, end)| format!(" [{}-{}]", start, end))
+            .unwrap_or_default();
         result.push_str(&format!(
-            "{}{}{}{} {}\n",
-            prefix, connector, space, marker, self.heading.text
+            "{}{}{}{} {}{}\n",
+            prefix, connector, space, marker, self.heading.text, line_suffix
         ));
 
         let child_prefix = format!("{}{}", prefix, continuation);
 
         for (i, child) in self.children.iter().enumerate() {
             let is_last_child = i == self.children.len() - 1;
-            result.push_str(&child.render_box_tree_styled(&child_prefix, is_last_child, compact));
+            result.push_str(&child.render_box_tree_inner(
+                &child_prefix,
+                is_last_child,
+                compact,
+                ranges,
+            ));
         }
 
         result
@@ -642,5 +715,52 @@ mod tests {
         let solo_idx = d.headings.iter().position(|h| h.text == "Solo").unwrap();
         let body = d.extract_section_at_index(solo_idx).unwrap();
         assert_eq!(body, "");
+    }
+
+    // ---------- heading_line_ranges ----------
+
+    #[test]
+    fn heading_line_ranges_flat_siblings_partition_the_document() {
+        let d = crate::parser::parse_markdown("# A\nline2\n\n# B\nline5\n\n# C\nline8\n");
+        let ranges = d.heading_line_ranges();
+        let a = d.headings.iter().find(|h| h.text == "A").unwrap();
+        let b = d.headings.iter().find(|h| h.text == "B").unwrap();
+        let c = d.headings.iter().find(|h| h.text == "C").unwrap();
+        assert_eq!(ranges[&a.offset], (1, 3));
+        assert_eq!(ranges[&b.offset], (4, 6));
+        assert_eq!(ranges[&c.offset], (7, 8));
+    }
+
+    #[test]
+    fn heading_line_ranges_parent_range_spans_its_children() {
+        // # A (line 1) nests ## B (line 2) and ## C (line 4); # D (line 6)
+        // follows at the same level as A, so A's range stops right before it.
+        let d = crate::parser::parse_markdown("# A\n## B\nb-body\n## C\nc-body\n# D\nd-body\n");
+        let ranges = d.heading_line_ranges();
+        let a = d.headings.iter().find(|h| h.text == "A").unwrap();
+        let b = d.headings.iter().find(|h| h.text == "B").unwrap();
+        let c = d.headings.iter().find(|h| h.text == "C").unwrap();
+        let dd = d.headings.iter().find(|h| h.text == "D").unwrap();
+        assert_eq!(ranges[&a.offset], (1, 5), "A spans through both children");
+        assert_eq!(ranges[&b.offset], (2, 3));
+        assert_eq!(ranges[&c.offset], (4, 5));
+        assert_eq!(ranges[&dd.offset], (6, 7));
+    }
+
+    #[test]
+    fn heading_line_ranges_last_heading_ends_at_last_document_line() {
+        let d = crate::parser::parse_markdown("# A\nbody1\n# B\nbody2\nbody3\n");
+        let ranges = d.heading_line_ranges();
+        let b = d.headings.iter().find(|h| h.text == "B").unwrap();
+        assert_eq!(ranges[&b.offset], (3, 5));
+    }
+
+    #[test]
+    fn heading_line_ranges_no_trailing_newline_still_counts_last_line() {
+        // No trailing "\n" after "end" — it must still count as its own line.
+        let d = crate::parser::parse_markdown("# A\nbody\n\n## B\nend");
+        let ranges = d.heading_line_ranges();
+        let b = d.headings.iter().find(|h| h.text == "B").unwrap();
+        assert_eq!(ranges[&b.offset], (4, 5));
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -227,6 +227,71 @@ fn tree_with_level_narrows_tree() {
 }
 
 // ------------------------------------------------------------------
+// -n / --line-numbers
+// ------------------------------------------------------------------
+
+#[test]
+fn list_with_line_numbers_appends_ranges() {
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", "-n", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 5);
+    // "Title" is h1 and nests every other heading in the fixture, so its
+    // range must run through the end of the document.
+    assert_eq!(lines[0], "# Title [1-24]");
+    // "Conclusion" is the last heading and has no children.
+    assert_eq!(lines[4], "## Conclusion [22-24]");
+    for line in &lines {
+        assert!(
+            line.contains('[') && line.ends_with(']'),
+            "missing line range: {line}"
+        );
+    }
+}
+
+#[test]
+fn list_without_line_numbers_has_no_ranges() {
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(!stdout.contains('['), "unexpected line range: {stdout}");
+}
+
+#[test]
+fn tree_with_line_numbers_appends_ranges() {
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["--tree", "-n", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("Title [1-24]"));
+    assert!(stdout.contains("Conclusion [22-24]"));
+}
+
+#[test]
+fn list_with_line_numbers_and_level_filter_keeps_document_wide_ranges() {
+    // Ranges must reflect the full document even when the *displayed* set
+    // of headings is narrowed by --level.
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", "-n", "-L", "2", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].starts_with("## Installation ["));
+    assert!(lines[1].starts_with("## Usage ["));
+    assert!(lines[2].starts_with("## Conclusion ["));
+}
+
+#[test]
+fn list_json_output_ignores_line_numbers_flag() {
+    let f = fixture_file();
+    let (with_n, _, code1) = run(&["-l", "-n", "-o", "json", f.to_str().unwrap()]);
+    let (without_n, _, code2) = run(&["-l", "-o", "json", f.to_str().unwrap()]);
+    assert_eq!(code1, 0);
+    assert_eq!(code2, 0);
+    assert_eq!(with_n, without_n, "-n should not affect JSON output");
+}
+
+// ------------------------------------------------------------------
 // -s / --section
 // ------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #72

## Summary

- Adds `-n` / `--line-numbers` — combine with `--list` or `--tree` (plain output) to append each heading's `[start-end]` 1-indexed line range.
- `start` is the line the heading itself is on. `end` is the last line before the next heading at the same or a shallower level, mirroring the existing `section_end` "subtree" boundary used by `-s`/`extract_section` — or the document's last line if none follows. This means a parent heading's range spans through its children's ranges, e.g.:
  ```
  # Title [1-24]
  ## Installation [5-13]
  ## Usage [14-21]
  ### Advanced [18-21]
  ## Conclusion [22-24]
  ```
- Implemented as `Document::heading_line_ranges()` (a single sequential pass over the heading list, O(content_len) for line counting) returning a `HashMap<offset, (start, end)>`, plus `HeadingNode::render_box_tree_with_lines(...)` for the `--tree` case. Existing `render_box_tree`/`render_box_tree_styled` are untouched (both now delegate to a shared private `render_box_tree_inner`).
- `-n` has no effect on `-o json` (JSON already exposes `position.line`) or on `--count`/`-s`/`--at-line`.
- Works correctly with `--filter`/`-L`: line ranges are always computed against the full document, not the filtered subset, so a narrowed `--list -L 2` still reports accurate ranges.

## Motivation

Filed in #72: when using `treemd` output to steer an LLM through a large Markdown document, only having heading text/hierarchy means the LLM still has to load the whole file (or the JSON output) to know which lines to read. A plain `## Section [12-34]` line lets an agent fetch exactly the lines it needs.

We considered piping `-l -o json` (which already carries `position.line`) as a workaround, but that has two problems for this use case: the nested JSON payload costs far more tokens than a flat heading list, and deeply nested JSON is harder for smaller/simpler models to reliably parse and flatten into ranges. A native flag with plain-text output avoids both.

## Test plan

- [x] `cargo test` — full suite passes (units, `cli_integration`, `query_integration`, doctests)
- [x] Added unit tests in `src/parser/document.rs` for `heading_line_ranges` (flat siblings, parent spanning children, last heading to EOF, no-trailing-newline)
- [x] Added integration tests in `tests/cli_integration.rs` covering `-l -n`, `--tree -n`, `-n` combined with `-L`, and confirming `-n` is a no-op for `-o json`
- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean
- [x] Manually verified against fixtures with/without trailing newline and via stdin