### PR TITLE
chore(ci): group Cargo patch bumps into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      # Patch bumps are the only ones Cargo treats as compatible for both 1.0+
+      # and pre-1.0 crates, so they can land as one PR. Minor bumps stay on
+      # their own: for a pre-1.0 dependency a minor bump is a breaking change
+      # (resvg 0.47 -> 0.48 swapped its whole text-shaping backend), and it
+      # needs an isolated CI run to be worth anything.
+      cargo-patch:
+        update-types:
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Six separate PRs landed for one week of dependency updates (#65-#71), five of which were single-line lockfile patches. This groups patch-level Cargo updates so they arrive as one PR.

Minor bumps stay ungrouped on purpose. Dependabot labels a pre-1.0 bump like resvg 0.47 -> 0.48 as `semver-minor`, but under Cargo's rules that is a breaking change — that upgrade swapped rustybuzz for harfrust across the entire text-shaping path. Bundling it with trivial patches would have hidden it behind a single green check.

Patch is the one update type Cargo treats as compatible for both 1.0+ and pre-1.0 crates, which makes it the natural grouping boundary.

GitHub Actions updates are left ungrouped; happy to do the same there if the noise is worth it.