### PR TITLE
feat(cli): add -n to show each heading's source line range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-n`/`--line-numbers` appends each heading's source line range** - `treemd -l -n` emits `## Usage [14-21]`, and `--tree -n` annotates the tree the same way. A range runs from the heading's own line to the line before the next heading at the same or a higher level, so a parent's range covers its subsections. Reading a single section no longer means pulling in the whole file, or post-processing `-o json` to work out where a section ends
+
 ## [0.7.0] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -287,6 +287,26 @@ treemd -l --filter "usage" README.md    # Filter by text
 treemd -l -L 2 README.md                # Only ## headings
 ```
 
+#### Show line ranges
+
+```bash
+treemd -l -n README.md                  # Append [start-end] to each heading
+treemd --tree -n README.md              # Same, on the tree view
+```
+
+Each range runs from the heading's own line to the line before the next heading
+at the same or a higher level, so a parent's range covers its subsections:
+
+```
+# Title [1-24]
+## Installation [5-13]
+## Usage [14-21]
+### Advanced [18-21]
+```
+
+Handy for reading just the lines you need out of a large file — including for
+tools and agents that would otherwise pull in the whole document.
+
 #### Count and JSON output
 
 ```bash

--- a/skills/treemd/SKILL.md
+++ b/skills/treemd/SKILL.md
@@ -42,7 +42,24 @@ Understand the document skeleton before diving in.
 treemd --tree FILE.md              # Visual tree with box-drawing characters
 treemd --count FILE.md             # Heading count by level (h1–h6 breakdown + total)
 treemd -l FILE.md | head -20       # Quick scan of all headings
+treemd -l -n FILE.md               # Headings with [start-end] line ranges
 ```
+
+`-n` (`--line-numbers`) appends each section's source line range, so you can read
+just the lines you need instead of the whole file:
+
+```
+# Title [1-24]
+## Installation [5-13]
+## Usage [14-21]
+### Advanced [18-21]
+```
+
+A range runs from the heading's own line to the line before the next heading at
+the same or a higher level, so a parent's range covers its subsections
+(`## Usage [14-21]` contains `### Advanced [18-21]`). Filtering with `-L`/`--filter`
+narrows which headings print but never renumbers them. Works with `--tree` too;
+it has no effect on `-o json`, which reports positions in its own schema.
 
 ### Step 2: Locate
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -85,6 +85,19 @@ pub struct Cli {
     #[arg(long = "tree")]
     pub tree: bool,
 
+    /// Append each heading's source line range as [start-end]
+    ///
+    /// Works with --list and --tree in plain output. A heading's range runs from
+    /// its own line to the line before the next heading at the same or a higher
+    /// level, so a parent's range covers its subsections.
+    ///
+    /// Lets a reader jump straight to a section instead of scanning the file.
+    /// Has no effect on `-o json`, which reports positions in its own schema.
+    ///
+    /// Example: treemd -l -n README.md
+    #[arg(short = 'n', long = "line-numbers")]
+    pub line_numbers: bool,
+
     /// Filter headings by text pattern (case-insensitive)
     ///
     /// Only shows headings containing the specified text.

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,15 +428,26 @@ fn handle_cli_mode(args: &Cli, doc: &Document) {
         return;
     }
 
+    // Ranges are computed over the whole document, not the filtered subset: a
+    // section's extent does not change because the view was narrowed. Keyed by
+    // byte offset so a filtered heading still finds its own range.
+    let ranges: Option<HashMap<usize, (usize, usize)>> = args.line_numbers.then(|| {
+        doc.headings
+            .iter()
+            .map(|h| h.offset)
+            .zip(doc.heading_line_ranges())
+            .collect()
+    });
+
     // Handle different modes
     if args.count {
         print_heading_counts(doc);
     } else if args.tree {
-        print_tree(doc, &args.output, &headings);
+        print_tree(doc, &args.output, &headings, ranges.as_ref());
     } else if let Some(ref section_name) = args.section {
         extract_section(doc, section_name);
     } else if args.list {
-        print_headings(&headings, &args.output, doc);
+        print_headings(&headings, &args.output, doc, ranges.as_ref());
     }
 }
 
@@ -478,12 +489,22 @@ fn print_heading_at_line(doc: &Document, target_line: usize) {
     }
 }
 
-fn print_headings(headings: &[&parser::Heading], format: &OutputFormat, doc: &Document) {
+fn print_headings(
+    headings: &[&parser::Heading],
+    format: &OutputFormat,
+    doc: &Document,
+    ranges: Option<&HashMap<usize, (usize, usize)>>,
+) {
     match format {
         OutputFormat::Plain => {
             for heading in headings {
                 let prefix = "#".repeat(heading.level);
-                println!("{} {}", prefix, heading.text);
+                match ranges.and_then(|r| r.get(&heading.offset)) {
+                    Some((start, end)) => {
+                        println!("{} {} [{}-{}]", prefix, heading.text, start, end)
+                    }
+                    None => println!("{} {}", prefix, heading.text),
+                }
             }
         }
         OutputFormat::Json => {
@@ -500,7 +521,12 @@ fn print_headings(headings: &[&parser::Heading], format: &OutputFormat, doc: &Do
     }
 }
 
-fn print_tree(doc: &Document, format: &OutputFormat, headings: &[&parser::Heading]) {
+fn print_tree(
+    doc: &Document,
+    format: &OutputFormat,
+    headings: &[&parser::Heading],
+    ranges: Option<&HashMap<usize, (usize, usize)>>,
+) {
     // Build the tree from the (possibly filtered) heading subset so that
     // --tree --filter / --tree --level honor the docstring. When no filter
     // is in play, `headings` is the full list and we get the same tree as
@@ -520,7 +546,10 @@ fn print_tree(doc: &Document, format: &OutputFormat, headings: &[&parser::Headin
         OutputFormat::Tree | OutputFormat::Plain => {
             for (i, node) in tree.iter().enumerate() {
                 let is_last = i == tree.len() - 1;
-                print!("{}", node.render_box_tree_styled("", is_last, compact));
+                print!(
+                    "{}",
+                    node.render_box_tree_annotated("", is_last, compact, ranges)
+                );
             }
         }
         OutputFormat::Json => {

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -4,6 +4,7 @@
 //! markdown documents and their heading hierarchy.
 
 use serde::Serialize;
+use std::collections::HashMap;
 
 /// A markdown document with its content and structure.
 ///
@@ -216,6 +217,80 @@ impl Document {
             .map(|h| h.offset)
             .unwrap_or(self.content.len())
     }
+
+    /// Total number of source lines. A trailing newline does not open a new line.
+    fn total_lines(&self) -> usize {
+        if self.content.is_empty() {
+            return 0;
+        }
+        let newlines = self.content.matches('\n').count();
+        if self.content.ends_with('\n') {
+            newlines
+        } else {
+            newlines + 1
+        }
+    }
+
+    /// 1-indexed source line of each heading, parallel to `self.headings`.
+    ///
+    /// Counts newlines between consecutive heading offsets in a single pass so
+    /// the whole call is O(content_len) rather than O(headings * content_len),
+    /// matching how `--at-line` walks the document.
+    fn heading_lines(&self) -> Vec<usize> {
+        let mut lines = Vec::with_capacity(self.headings.len());
+        let mut line = 1usize;
+        let mut cursor = 0usize;
+
+        for heading in &self.headings {
+            // Headings arrive in ascending offset order. Clamping keeps this
+            // total for hand-built documents (e.g. the filtered tree, which
+            // pairs real headings with empty content).
+            let target = heading.offset.min(self.content.len());
+            if target >= cursor {
+                line += self.content[cursor..target].matches('\n').count();
+                cursor = target;
+            }
+            lines.push(line);
+        }
+
+        lines
+    }
+
+    /// 1-indexed inclusive `(start, end)` line range of every heading's section,
+    /// parallel to `self.headings`.
+    ///
+    /// `start` is the line the heading itself sits on. `end` is the line before
+    /// the next heading at the same or a higher level, so a parent's range spans
+    /// its subsections; the last such heading runs to the end of the document.
+    /// Back-to-back headings collapse to a single line (`end == start`).
+    pub fn heading_line_ranges(&self) -> Vec<(usize, usize)> {
+        let starts = self.heading_lines();
+        let total = self.total_lines();
+        let mut ranges = vec![(0, 0); self.headings.len()];
+
+        // Walk backwards tracking, per level, the start line of the nearest
+        // following heading that closes a section at that level.
+        const MAX_LEVEL: usize = 6;
+        let mut next_closing = [usize::MAX; MAX_LEVEL + 1];
+
+        for idx in (0..self.headings.len()).rev() {
+            let level = self.headings[idx].level.clamp(1, MAX_LEVEL);
+            let start = starts[idx];
+            let end = if next_closing[level] == usize::MAX {
+                total
+            } else {
+                next_closing[level].saturating_sub(1)
+            };
+            ranges[idx] = (start, end.max(start));
+
+            // This heading closes any section at its level or deeper.
+            for slot in next_closing.iter_mut().take(MAX_LEVEL + 1).skip(level) {
+                *slot = start;
+            }
+        }
+
+        ranges
+    }
 }
 
 impl HeadingNode {
@@ -227,6 +302,23 @@ impl HeadingNode {
 
     /// Render as tree with box-drawing characters, with optional compact style
     pub fn render_box_tree_styled(&self, prefix: &str, is_last: bool, compact: bool) -> String {
+        self.render_box_tree_annotated(prefix, is_last, compact, None)
+    }
+
+    /// Render as tree with box-drawing characters, optionally appending each
+    /// heading's `[start-end]` source line range.
+    ///
+    /// `ranges` maps a heading's byte offset to its line range (see
+    /// [`Document::heading_line_ranges`]). Offsets are stable across the
+    /// filtered-tree rebuild, so the map is keyed on them rather than on
+    /// position within a possibly-filtered heading list.
+    pub fn render_box_tree_annotated(
+        &self,
+        prefix: &str,
+        is_last: bool,
+        compact: bool,
+        ranges: Option<&HashMap<usize, (usize, usize)>>,
+    ) -> String {
         let mut result = String::new();
 
         let (connector, space, continuation) = if compact {
@@ -246,16 +338,25 @@ impl HeadingNode {
         };
 
         let marker = "#".repeat(self.heading.level);
+        let suffix = ranges
+            .and_then(|r| r.get(&self.heading.offset))
+            .map(|(start, end)| format!(" [{}-{}]", start, end))
+            .unwrap_or_default();
         result.push_str(&format!(
-            "{}{}{}{} {}\n",
-            prefix, connector, space, marker, self.heading.text
+            "{}{}{}{} {}{}\n",
+            prefix, connector, space, marker, self.heading.text, suffix
         ));
 
         let child_prefix = format!("{}{}", prefix, continuation);
 
         for (i, child) in self.children.iter().enumerate() {
             let is_last_child = i == self.children.len() - 1;
-            result.push_str(&child.render_box_tree_styled(&child_prefix, is_last_child, compact));
+            result.push_str(&child.render_box_tree_annotated(
+                &child_prefix,
+                is_last_child,
+                compact,
+                ranges,
+            ));
         }
 
         result
@@ -642,5 +743,76 @@ mod tests {
         let solo_idx = d.headings.iter().position(|h| h.text == "Solo").unwrap();
         let body = d.extract_section_at_index(solo_idx).unwrap();
         assert_eq!(body, "");
+    }
+
+    // ---------- heading_line_ranges ----------
+
+    #[test]
+    fn line_ranges_empty_document() {
+        let d = doc("", vec![]);
+        assert!(d.heading_line_ranges().is_empty());
+    }
+
+    #[test]
+    fn line_ranges_parent_spans_its_subsections() {
+        // A parent's range covers its children; each h2 stops at the next h2.
+        let d =
+            crate::parser::parse_markdown("# A\nintro\n## B\nb body\n## C\nc body\n# D\nd body\n");
+        assert_eq!(
+            d.heading_line_ranges(),
+            vec![(1, 6), (3, 4), (5, 6), (7, 8)]
+        );
+    }
+
+    #[test]
+    fn line_ranges_deeper_heading_stops_at_shallower_one() {
+        // The h3 must end where the following h2 begins, not run to EOF.
+        let d = crate::parser::parse_markdown("# A\n## B\n### C\ntext\n## D\n");
+        assert_eq!(
+            d.heading_line_ranges(),
+            vec![(1, 5), (2, 4), (3, 4), (5, 5)]
+        );
+    }
+
+    #[test]
+    fn line_ranges_back_to_back_headings_collapse_to_one_line() {
+        let d = crate::parser::parse_markdown("# A\n# B\n");
+        assert_eq!(d.heading_line_ranges(), vec![(1, 1), (2, 2)]);
+    }
+
+    #[test]
+    fn line_ranges_last_section_runs_to_eof_without_trailing_newline() {
+        // A missing final newline must not lose the last line.
+        let d = crate::parser::parse_markdown("# A\nbody");
+        assert_eq!(d.heading_line_ranges(), vec![(1, 2)]);
+    }
+
+    #[test]
+    fn line_ranges_ignore_headings_inside_code_blocks() {
+        // The fenced "# fake" must neither become a heading nor shift the
+        // line numbers of the real one that follows.
+        let d = crate::parser::parse_markdown("# A\n```\n# fake\n```\n## B\nbody\n");
+        assert_eq!(d.heading_line_ranges(), vec![(1, 6), (5, 6)]);
+    }
+
+    #[test]
+    fn line_ranges_count_crlf_lines_once() {
+        let d = crate::parser::parse_markdown("# A\r\n## B\r\ntext\r\n");
+        assert_eq!(d.heading_line_ranges(), vec![(1, 3), (2, 3)]);
+    }
+
+    #[test]
+    fn line_ranges_span_setext_underlines() {
+        // The h1's range must cover the setext underline rows too.
+        let d = crate::parser::parse_markdown("Title\n=====\nbody\n\nSub\n-----\nsub body\n");
+        assert_eq!(d.heading_line_ranges(), vec![(1, 7), (5, 7)]);
+    }
+
+    #[test]
+    fn line_ranges_tolerate_offsets_past_content() {
+        // The filtered `--tree` path pairs real headings with empty content;
+        // this must clamp rather than panic on an out-of-bounds slice.
+        let d = doc("", vec![h(1, "A", 40), h(2, "B", 80)]);
+        assert_eq!(d.heading_line_ranges(), vec![(1, 1), (1, 1)]);
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -227,6 +227,96 @@ fn tree_with_level_narrows_tree() {
 }
 
 // ------------------------------------------------------------------
+// -n / --line-numbers
+// ------------------------------------------------------------------
+
+#[test]
+fn line_numbers_append_ranges_to_list() {
+    // Ranges are derived from FIXTURE's layout: the h1 spans the whole doc,
+    // each h2 stops before the next h2, and the h3 stops at "## Conclusion".
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", "-n", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "# Title [1-24]",
+            "## Installation [5-13]",
+            "## Usage [14-21]",
+            "### Advanced [18-21]",
+            "## Conclusion [22-24]",
+        ],
+        "unexpected ranges: {stdout}"
+    );
+}
+
+#[test]
+fn line_numbers_are_absent_without_the_flag() {
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(!stdout.contains('['), "ranges leaked without -n: {stdout}");
+}
+
+#[test]
+fn line_numbers_annotate_tree_output() {
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["--tree", "-n", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("# Title [1-24]"), "got: {stdout}");
+    assert!(stdout.contains("### Advanced [18-21]"), "got: {stdout}");
+    assert!(stdout.contains("├") || stdout.contains("└"), "no branches");
+}
+
+#[test]
+fn line_numbers_keep_document_ranges_when_filtered() {
+    // Narrowing the view must not renumber sections: "## Usage" still ends
+    // where "## Conclusion" starts, even though the h3 is filtered out.
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", "-n", "-L", "2", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "## Installation [5-13]",
+            "## Usage [14-21]",
+            "## Conclusion [22-24]",
+        ],
+        "filtered ranges should match the unfiltered document: {stdout}"
+    );
+}
+
+#[test]
+fn line_numbers_ranges_are_contiguous_and_ordered() {
+    // Every range must be well-formed (start <= end) and start on the line
+    // the heading actually occupies.
+    let f = fixture_file();
+    let (stdout, _, code) = run(&["-l", "-n", f.to_str().unwrap()]);
+    assert_eq!(code, 0);
+
+    let source = std::fs::read_to_string(&f).expect("read fixture");
+    let source_lines: Vec<_> = source.lines().collect();
+
+    for line in stdout.lines() {
+        let (heading, range) = line.rsplit_once(" [").expect("range suffix");
+        let range = range.strip_suffix(']').expect("closing bracket");
+        let (start, end) = range.split_once('-').expect("start-end");
+        let start: usize = start.parse().expect("numeric start");
+        let end: usize = end.parse().expect("numeric end");
+
+        assert!(start <= end, "inverted range in {line}");
+        assert!(end <= source_lines.len(), "range past EOF in {line}");
+        assert_eq!(
+            source_lines[start - 1].trim(),
+            heading,
+            "range start does not point at its own heading"
+        );
+    }
+}
+
+// ------------------------------------------------------------------
 // -s / --section
 // ------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #72.

`treemd -l -n` appends `[start-end]` to every heading, and `--tree -n` annotates the tree the same way:

```
# Title [1-24]
## Installation [5-13]
## Usage [14-21]
### Advanced [18-21]
## Conclusion [22-24]
```

## Range semantics

A range runs from the heading's own line to the line before the next heading at the same or a higher level, so a parent's range covers its subsections. That is the same boundary rule `-s`/`--section` already uses, so `-n` and `-s` agree on where a section ends.

The issue's prose specified this rule, though its worked example and its Python workaround disagreed with each other — the workaround used flat next-heading boundaries, which would have reported `# tituloA [1-2]` rather than the `[1-20]` in the example. The prose rule is what's implemented here.

## Notes

- Ranges are computed over the whole document and keyed by byte offset, so `-L` and `--filter` choose which headings print without renumbering them. `## Usage [14-21]` reports the same range whether or not the nested h3 is filtered out.
- Line numbers come from a single pass over the content, matching how `--at-line` already walks the document, rather than rescanning per heading.
- No effect on `-o json`, which reports positions in its own schema. Documented in the flag help.

## Tests

14 new tests. Unit coverage for the range rule: nesting, back-to-back headings, missing trailing newline, CRLF, setext underlines, headings inside fenced code blocks, and out-of-bounds offsets (the filtered-tree path builds a `Document` with empty content, which would otherwise panic on a byte slice). Integration coverage for `-l -n`, `--tree -n`, filtered ranges, and absence of ranges without the flag.

Full suite passes (388), plus clippy `-D warnings` on all targets/features and on `--no-default-features`. Verified by hand against this repo's README: `## Installation [84-125]` sits exactly between line 84 (`## Installation`) and line 126 (`## Usage`).