### PR TITLE
feat(tui): add code fence and background options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`-n` / `--line-numbers`** - `--list` and `--tree` can now append each heading's `[start-end]` line range in plain output, so a section can be fetched by line range instead of loaded in full — useful for keeping LLM context small
+- **Code block fence and background options** - `[content] code_fences` takes `full` (unchanged), `label` (a dim language name above the block, no closing row), or `none`. Fence rows are dropped rather than hidden, so they cost no vertical space. `[theme] code_block_bg` overrides the block background, or `"none"` disables it
+
+### Changed
+
+- **Code blocks are painted with the code theme's background** - Only syntect token foregrounds were used before, so a code theme's background was discarded and blocks had no way to stand out from surrounding prose. The background now covers the full block width, padding included, and can be overridden or turned off with `[theme] code_block_bg`
 
 ## [0.7.0] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,35 @@ color_mode = "auto"    # "auto", "rgb", or "256"
 [content]
 hide_frontmatter = true  # Hide YAML frontmatter (---\n...\n---) in content view
 hide_latex = true        # Hide LaTeX math expressions ($...$, $$...$$, \begin{...})
+code_fences = "full"     # "full", "label", or "none" (see below)
 ```
+
+### Code Block Appearance
+
+`code_fences` controls how a fenced code block is delimited in the content pane.
+The rows are removed rather than hidden, so they take no vertical space.
+
+| Value | Result |
+|-------|--------|
+| `full` | Both fence rows, as written in the source: ` ```rust ` and ` ``` ` |
+| `label` | A dim language name above the block, and no closing row |
+| `none` | No fence rows at all |
+
+With `label`, a block with no language gets no label row either. The name sits
+on its own row rather than on the first line of code, so selecting the block
+with the mouse does not drag it in.
+
+The code block background comes from the code theme by default, so it agrees
+with the syntax colors. Override or disable it:
+
+```toml
+[theme]
+code_block_bg = { rgb = [40, 40, 50] }  # explicit color
+# code_block_bg = "none"                # leave code on the terminal background
+```
+
+The background covers the full width of the block, including padding, so short
+lines do not leave a ragged edge.
 
 ### Custom Keybindings
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,31 @@ pub struct ContentConfig {
     /// Enable this if standard filtering misses some LaTeX commands
     #[serde(default = "default_latex_aggressive")]
     pub latex_aggressive: bool,
+
+    /// How to mark the edges of a fenced code block (default: full)
+    #[serde(default)]
+    pub code_fences: CodeFences,
+}
+
+/// How fenced code blocks are delimited in the rendered content pane.
+///
+/// The fence rows are decoration, not content, so they can be dropped
+/// entirely. They are removed rather than hidden, so they take no vertical
+/// space either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CodeFences {
+    /// Both fence rows, as written in the source: ```lang and ```
+    #[default]
+    Full,
+    /// A dim language label above the block, and no closing row.
+    ///
+    /// Keeps the language visible without boxing the block in. The label sits
+    /// on its own row rather than on the first line of code, so selecting the
+    /// block with the mouse does not pick it up.
+    Label,
+    /// No fence rows at all.
+    None,
 }
 
 impl Default for ContentConfig {
@@ -109,6 +134,7 @@ impl Default for ContentConfig {
             hide_frontmatter: default_hide_frontmatter(),
             hide_latex: default_hide_latex(),
             latex_aggressive: default_latex_aggressive(),
+            code_fences: CodeFences::default(),
         }
     }
 }
@@ -170,6 +196,14 @@ pub struct CustomThemeConfig {
     pub blockquote_fg: Option<ColorValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code_fence: Option<ColorValue>,
+    /// Background for the whole code block area.
+    ///
+    /// Unlike the other keys here this one is not a field on `Theme`: it
+    /// belongs to the *code* theme, so when unset it falls back to the syntect
+    /// theme's own background and stays consistent with the token colors.
+    /// Resolved in `SyntaxHighlighter`, not `Theme::with_custom_colors`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_block_bg: Option<ColorValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_bar_fg: Option<ColorValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -569,6 +603,44 @@ mod tests {
         assert_eq!(c.ui.outline_width, 30); // default
         assert_eq!(c.terminal.color_mode, "auto"); // default
         assert!(c.content.hide_frontmatter); // default
+    }
+
+    #[test]
+    fn config_code_fences_defaults_to_full_and_parses_each_mode() {
+        let c: Config = toml::from_str("[ui]\ntheme = \"Nord\"\n").expect("parse");
+        assert_eq!(c.content.code_fences, CodeFences::Full);
+
+        for (value, want) in [
+            ("full", CodeFences::Full),
+            ("label", CodeFences::Label),
+            ("none", CodeFences::None),
+        ] {
+            let s = format!("[content]\ncode_fences = \"{value}\"\n");
+            let c: Config = toml::from_str(&s).unwrap_or_else(|e| panic!("{value}: {e}"));
+            assert_eq!(c.content.code_fences, want, "for {value}");
+        }
+    }
+
+    #[test]
+    fn config_code_block_bg_accepts_a_color_or_none() {
+        // Unset means "fall back to the code theme's background".
+        let c: Config = toml::from_str("[ui]\ntheme = \"Nord\"\n").expect("parse");
+        assert!(c.theme.code_block_bg.is_none());
+
+        let s = "[theme]\ncode_block_bg = { rgb = [40, 40, 50] }\n";
+        let c: Config = toml::from_str(s).expect("rgb");
+        assert!(matches!(
+            c.theme.code_block_bg,
+            Some(ColorValue::Rgb { rgb: [40, 40, 50] })
+        ));
+
+        // "none" is how the background gets turned off entirely.
+        let s = "[theme]\ncode_block_bg = \"none\"\n";
+        let c: Config = toml::from_str(s).expect("none");
+        assert!(matches!(
+            c.theme.code_block_bg,
+            Some(ColorValue::Named(ref n)) if n == "none"
+        ));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,7 +6,7 @@ use crate::tui::image_cache::{AsyncProtocol, GifAdvance, ImageWorker, StreamingG
 use crate::tui::interactive::{ElementType, InteractiveState};
 use crate::tui::iterm_animation;
 use crate::tui::kitty_animation::{self, KittyAnimation};
-use crate::tui::syntax::SyntaxHighlighter;
+use crate::tui::syntax::{CodeBlockBackground, SyntaxHighlighter};
 use crate::tui::terminal_compat::ColorMode;
 use crate::tui::theme::{Theme, ThemeName};
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -530,6 +530,7 @@ pub struct App {
     pub highlighter: SyntaxHighlighter,
     pub show_outline: bool,
     pub show_heading_markers: bool, // Show # prefixes in outline sidebar
+    pub code_fences: crate::config::CodeFences, // How to delimit fenced code blocks
     /// Whether terminal mouse capture is active. When on, the scroll wheel drives
     /// navigation but the terminal's native click-drag text selection is disabled.
     /// Toggling it off hands the mouse back to the terminal so text can be selected
@@ -740,6 +741,22 @@ impl App {
         let code_theme_dir = config.code_theme_dir_path();
         // Load sublime color scheme name (for code highlighting)
         let code_theme = config.ui.code_theme.as_str();
+        // Code block background: unset falls back to the code theme's own, and
+        // the literal "none" turns it off for anyone who prefers code to sit on
+        // the terminal background.
+        let code_block_bg = match config.theme.code_block_bg.as_ref() {
+            None => CodeBlockBackground::FromTheme,
+            Some(crate::config::ColorValue::Named(name)) if name.eq_ignore_ascii_case("none") => {
+                CodeBlockBackground::Off
+            }
+            Some(value) => match value.to_color() {
+                Some(c) if matches!(color_mode, ColorMode::Indexed256) => {
+                    CodeBlockBackground::Color(crate::tui::theme::rgb_to_256(c))
+                }
+                Some(c) => CodeBlockBackground::Color(c),
+                None => CodeBlockBackground::FromTheme,
+            },
+        };
 
         // Load outline width from config
         let outline_width = config.ui.outline_width;
@@ -774,9 +791,10 @@ impl App {
             show_search: false,
             outline_search_active: false,
             search_query: String::new(),
-            highlighter: SyntaxHighlighter::new(code_theme, code_theme_dir),
+            highlighter: SyntaxHighlighter::new(code_theme, code_theme_dir, code_block_bg),
             show_outline: true,
             show_heading_markers: config.ui.outline_heading_markers,
+            code_fences: config.content.code_fences,
             mouse_capture: true,
             outline_width,
             config_has_custom_outline_width,

--- a/src/tui/syntax.rs
+++ b/src/tui/syntax.rs
@@ -12,6 +12,19 @@ use syntect::util::LinesWithEndings;
 
 const DEFAULT_CODE_THEME: &str = "base16-ocean.dark";
 
+/// What to paint behind a code block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CodeBlockBackground {
+    /// The code theme's own background, so the block agrees with its token
+    /// colors. This is what an unset `code_block_bg` resolves to.
+    #[default]
+    FromTheme,
+    /// An explicit color from config.
+    Color(Color),
+    /// Paint nothing, leaving code on the terminal background.
+    Off,
+}
+
 /// Soft cap on cached entries before the cache resets. Each entry is a small
 /// `Vec<Line>` so 256 covers virtually any document while bounding memory.
 const CACHE_LIMIT: usize = 256;
@@ -19,13 +32,17 @@ const CACHE_LIMIT: usize = 256;
 pub struct SyntaxHighlighter {
     syntax_set: SyntaxSet,
     theme: Theme,
+    /// Background for the code block area, or `None` to leave it unpainted.
+    /// Config override if one was given, otherwise the code theme's own
+    /// background so it agrees with the token colors.
+    code_block_bg: Option<Color>,
     /// Cached highlight results keyed by `hash((content, language))`.
     /// `RefCell` because highlight_code takes `&self` and is called from render.
     cache: RefCell<HashMap<u64, Vec<Line<'static>>>>,
 }
 
 impl SyntaxHighlighter {
-    pub fn new(theme: &str, theme_dir: Option<PathBuf>) -> Self {
+    pub fn new(theme: &str, theme_dir: Option<PathBuf>, background: CodeBlockBackground) -> Self {
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let mut theme_set = ThemeSet::load_defaults();
         if let Some(dir) = theme_dir
@@ -60,11 +77,25 @@ impl SyntaxHighlighter {
             .cloned()
             .expect("syntect default themes must contain base16-ocean.dark");
 
+        let code_block_bg = match background {
+            CodeBlockBackground::Off => None,
+            CodeBlockBackground::Color(c) => Some(c),
+            CodeBlockBackground::FromTheme => {
+                theme.settings.background.map(|c| Color::Rgb(c.r, c.g, c.b))
+            }
+        };
+
         Self {
             syntax_set,
             theme,
+            code_block_bg,
             cache: RefCell::new(HashMap::new()),
         }
+    }
+
+    /// Background to paint behind a code block, if any.
+    pub fn code_block_bg(&self) -> Option<Color> {
+        self.code_block_bg
     }
 
     /// Highlight `code` as `language`. Result is memoized — repeat calls with

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1049,7 +1049,7 @@ impl Theme {
 }
 
 /// Convert RGB color to nearest 256-color palette entry
-fn rgb_to_256(color: Color) -> Color {
+pub(crate) fn rgb_to_256(color: Color) -> Color {
     match color {
         Color::Rgb(r, g, b) => {
             // Check if it's grayscale

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -1499,10 +1499,8 @@ fn render_markdown_enhanced(
             ContentBlock::Code {
                 language, content, ..
             } => {
-                let lang_str = language.as_deref().unwrap_or("");
-
                 #[cfg(all(feature = "mermaid", unix))]
-                let is_mermaid = lang_str == "mermaid";
+                let is_mermaid = language.as_deref() == Some("mermaid");
                 #[cfg(not(all(feature = "mermaid", unix)))]
                 let is_mermaid = false;
 
@@ -1543,41 +1541,13 @@ fn render_markdown_enhanced(
                         lines.push(Line::from(vec![]));
                     }
                 } else {
-                    // Standard code block: opening fence + highlighted code + closing fence
-                    let mut fence_spans = vec![];
-                    if is_block_selected {
-                        fence_spans.push(Span::styled(
-                            "→ ",
-                            Style::default()
-                                .fg(theme.selection_indicator_fg)
-                                .bg(theme.selection_indicator_bg)
-                                .add_modifier(Modifier::BOLD),
-                        ));
-                    }
-                    fence_spans.push(Span::styled(
-                        format!("```{}", lang_str),
-                        theme.code_fence_style(),
+                    lines.extend(render_code_block(
+                        language.as_deref(),
+                        content,
+                        highlighter,
+                        theme,
+                        is_block_selected,
                     ));
-
-                    #[cfg(not(all(feature = "mermaid", unix)))]
-                    if lang_str == "mermaid" {
-                        fence_spans.push(Span::styled(
-                            " (enable 'mermaid' feature to render)",
-                            Style::default().fg(Color::DarkGray),
-                        ));
-                    }
-
-                    lines.push(Line::from(fence_spans));
-
-                    // Highlighted code
-                    let highlighted = highlighter.highlight_code(content, lang_str);
-                    lines.extend(highlighted);
-
-                    // Closing fence
-                    lines.push(Line::from(vec![Span::styled(
-                        "```".to_string(),
-                        theme.code_fence_style(),
-                    )]));
                 }
             }
             ContentBlock::List { ordered, items } => {
@@ -2327,6 +2297,57 @@ fn render_callout_lines(content: &str, theme: &Theme) -> Option<Vec<Line<'static
     Some(lines)
 }
 
+/// Render a fenced code block: opening fence, highlighted body, closing fence.
+///
+/// Shared by the top-level renderer and the nested-block renderer so a code
+/// block inside a callout or `<details>` is styled the same as one at the top
+/// level. `selected` draws the block-selection indicator on the opening fence;
+/// the nested renderer has no notion of selection and passes `false`.
+fn render_code_block(
+    language: Option<&str>,
+    content: &str,
+    highlighter: &SyntaxHighlighter,
+    theme: &Theme,
+    selected: bool,
+) -> Vec<Line<'static>> {
+    let lang_str = language.unwrap_or("");
+    let mut lines = Vec::new();
+
+    let mut fence_spans = vec![];
+    if selected {
+        fence_spans.push(Span::styled(
+            "→ ",
+            Style::default()
+                .fg(theme.selection_indicator_fg)
+                .bg(theme.selection_indicator_bg)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    fence_spans.push(Span::styled(
+        format!("```{}", lang_str),
+        theme.code_fence_style(),
+    ));
+
+    #[cfg(not(all(feature = "mermaid", unix)))]
+    if lang_str == "mermaid" {
+        fence_spans.push(Span::styled(
+            " (enable 'mermaid' feature to render)",
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+
+    lines.push(Line::from(fence_spans));
+
+    lines.extend(highlighter.highlight_code(content, lang_str));
+
+    lines.push(Line::from(vec![Span::styled(
+        "```".to_string(),
+        theme.code_fence_style(),
+    )]));
+
+    lines
+}
+
 fn render_block_to_lines(
     block: &ContentBlock,
     highlighter: &SyntaxHighlighter,
@@ -2371,23 +2392,13 @@ fn render_block_to_lines(
         ContentBlock::Code {
             language, content, ..
         } => {
-            let lang_str = language.as_deref().unwrap_or("");
-
-            // Opening fence
-            lines.push(Line::from(vec![Span::styled(
-                format!("```{}", lang_str),
-                theme.code_fence_style(),
-            )]));
-
-            // Highlighted code
-            let highlighted = highlighter.highlight_code(content, lang_str);
-            lines.extend(highlighted);
-
-            // Closing fence
-            lines.push(Line::from(vec![Span::styled(
-                "```".to_string(),
-                theme.code_fence_style(),
-            )]));
+            lines.extend(render_code_block(
+                language.as_deref(),
+                content,
+                highlighter,
+                theme,
+                false,
+            ));
         }
         ContentBlock::Details {
             summary,

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod util;
 
 use layout::{DynamicLayout, Section};
 
+use crate::config::CodeFences;
 use crate::tui::app::{App, AppMode, Focus};
 use crate::tui::theme::Theme;
 use popups::{
@@ -448,6 +449,7 @@ fn render_content(frame: &mut Frame, app: &mut App, area: Rect) {
             Some(&interactive_state), // Pass cloned copy to release borrow
             Some(content_width),
             mermaid_rows_ref,
+            app.code_fences,
         )
     };
 
@@ -1396,6 +1398,7 @@ fn render_raw_markdown(content: &str, theme: &Theme) -> Text<'static> {
     Text::from(lines)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_markdown_enhanced(
     content: &str,
     highlighter: &SyntaxHighlighter,
@@ -1404,6 +1407,7 @@ fn render_markdown_enhanced(
     interactive_state: Option<&crate::tui::interactive::InteractiveState>,
     available_width: Option<u16>,
     _mermaid_placeholder_rows: &std::collections::HashMap<u64, usize>,
+    fences: CodeFences,
 ) -> Text<'static> {
     let mut lines = Vec::new();
 
@@ -1547,6 +1551,8 @@ fn render_markdown_enhanced(
                         highlighter,
                         theme,
                         is_block_selected,
+                        fences,
+                        available_width,
                     ));
                 }
             }
@@ -1758,8 +1764,13 @@ fn render_markdown_enhanced(
 
                         // Reduce width by indent (5 spaces)
                         let nested_width = available_width.map(|w| w.saturating_sub(5));
-                        let nested_lines =
-                            render_block_to_lines(nested_block, highlighter, theme, nested_width);
+                        let nested_lines = render_block_to_lines(
+                            nested_block,
+                            highlighter,
+                            theme,
+                            nested_width,
+                            fences,
+                        );
                         for (line_idx, nested_line) in nested_lines.into_iter().enumerate() {
                             let mut indented_spans = vec![];
 
@@ -1796,8 +1807,13 @@ fn render_markdown_enhanced(
                     for nested_block in nested {
                         // Reduce width by blockquote prefix (2 chars)
                         let nested_width = available_width.map(|w| w.saturating_sub(2));
-                        let nested_lines =
-                            render_block_to_lines(nested_block, highlighter, theme, nested_width);
+                        let nested_lines = render_block_to_lines(
+                            nested_block,
+                            highlighter,
+                            theme,
+                            nested_width,
+                            fences,
+                        );
                         for nested_line in nested_lines {
                             let mut spans = vec![Span::styled(
                                 "│ ",
@@ -2028,6 +2044,7 @@ fn render_markdown_enhanced(
                                 highlighter,
                                 theme,
                                 block_width,
+                                fences,
                             );
                             for (line_idx, nested_line) in nested_lines.into_iter().enumerate() {
                                 let mut spans = vec![];
@@ -2297,53 +2314,123 @@ fn render_callout_lines(content: &str, theme: &Theme) -> Option<Vec<Line<'static
     Some(lines)
 }
 
-/// Render a fenced code block: opening fence, highlighted body, closing fence.
+/// Paint `bg` across every line, padding each out to `width` so the block
+/// reads as one rectangle rather than a ragged right edge.
+///
+/// Spans that already carry a background are left alone: that is how the
+/// selection indicator keeps its own highlight.
+fn fill_block_background(lines: &mut [Line<'static>], bg: Color, width: usize) {
+    use unicode_width::UnicodeWidthStr;
+
+    for line in lines.iter_mut() {
+        let mut used = 0usize;
+        for span in &mut line.spans {
+            if span.style.bg.is_none() {
+                span.style = span.style.bg(bg);
+            }
+            used += UnicodeWidthStr::width(span.content.as_ref());
+        }
+        if used < width {
+            line.spans.push(Span::styled(
+                " ".repeat(width - used),
+                Style::default().bg(bg),
+            ));
+        }
+    }
+}
+
+/// Render a fenced code block: optional opening fence, highlighted body,
+/// optional closing fence.
 ///
 /// Shared by the top-level renderer and the nested-block renderer so a code
 /// block inside a callout or `<details>` is styled the same as one at the top
-/// level. `selected` draws the block-selection indicator on the opening fence;
-/// the nested renderer has no notion of selection and passes `false`.
+/// level. `selected` draws the block-selection indicator on the first row; the
+/// nested renderer has no notion of selection and passes `false`.
 fn render_code_block(
     language: Option<&str>,
     content: &str,
     highlighter: &SyntaxHighlighter,
     theme: &Theme,
     selected: bool,
+    fences: CodeFences,
+    available_width: Option<u16>,
 ) -> Vec<Line<'static>> {
     let lang_str = language.unwrap_or("");
     let mut lines = Vec::new();
 
-    let mut fence_spans = vec![];
-    if selected {
-        fence_spans.push(Span::styled(
-            "→ ",
-            Style::default()
-                .fg(theme.selection_indicator_fg)
-                .bg(theme.selection_indicator_bg)
-                .add_modifier(Modifier::BOLD),
-        ));
-    }
-    fence_spans.push(Span::styled(
-        format!("```{}", lang_str),
-        theme.code_fence_style(),
-    ));
+    // Opening row. `Full` reproduces the source fence; `Label` keeps only a dim
+    // language name; `None` drops it. The label sits on its own row either way,
+    // so a mouse selection of the code does not drag the language in with it.
+    match fences {
+        CodeFences::Full => {
+            // `mut` is only needed when the mermaid hint below is compiled in.
+            #[allow(unused_mut)]
+            let mut fence_spans = vec![Span::styled(
+                format!("```{}", lang_str),
+                theme.code_fence_style(),
+            )];
 
-    #[cfg(not(all(feature = "mermaid", unix)))]
-    if lang_str == "mermaid" {
-        fence_spans.push(Span::styled(
-            " (enable 'mermaid' feature to render)",
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
+            #[cfg(not(all(feature = "mermaid", unix)))]
+            if lang_str == "mermaid" {
+                fence_spans.push(Span::styled(
+                    " (enable 'mermaid' feature to render)",
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
 
-    lines.push(Line::from(fence_spans));
+            lines.push(Line::from(fence_spans));
+        }
+        CodeFences::Label if !lang_str.is_empty() => {
+            // `mut` is only needed when the mermaid hint below is compiled in.
+            #[allow(unused_mut)]
+            let mut label_spans = vec![Span::styled(
+                lang_str.to_string(),
+                theme.code_fence_style().add_modifier(Modifier::DIM),
+            )];
+
+            #[cfg(not(all(feature = "mermaid", unix)))]
+            if lang_str == "mermaid" {
+                label_spans.push(Span::styled(
+                    " (enable 'mermaid' feature to render)",
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+
+            lines.push(Line::from(label_spans));
+        }
+        CodeFences::Label | CodeFences::None => {}
+    }
 
     lines.extend(highlighter.highlight_code(content, lang_str));
 
-    lines.push(Line::from(vec![Span::styled(
-        "```".to_string(),
-        theme.code_fence_style(),
-    )]));
+    // Closing row only exists for `Full`. `Label` deliberately leaves the block
+    // open at the bottom so short blocks are not boxed in on every side.
+    if matches!(fences, CodeFences::Full) {
+        lines.push(Line::from(vec![Span::styled(
+            "```".to_string(),
+            theme.code_fence_style(),
+        )]));
+    }
+
+    if let Some(bg) = highlighter.code_block_bg() {
+        let width = available_width.map(usize::from).unwrap_or(0);
+        fill_block_background(&mut lines, bg, width);
+    }
+
+    // Added after the fill so the indicator keeps its own colors and the
+    // padding math above is not thrown off by its width.
+    if selected && let Some(first) = lines.first_mut() {
+        first.spans.insert(
+            0,
+            Span::styled(
+                "→ ",
+                Style::default()
+                    .fg(theme.selection_indicator_fg)
+                    .bg(theme.selection_indicator_bg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        );
+    }
 
     lines
 }
@@ -2353,6 +2440,7 @@ fn render_block_to_lines(
     highlighter: &SyntaxHighlighter,
     theme: &Theme,
     available_width: Option<u16>,
+    fences: CodeFences,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
@@ -2398,6 +2486,8 @@ fn render_block_to_lines(
                 highlighter,
                 theme,
                 false,
+                fences,
+                available_width,
             ));
         }
         ContentBlock::Details {
@@ -2421,7 +2511,7 @@ fn render_block_to_lines(
                 // Reduce width by indent (2 spaces)
                 let nested_width = available_width.map(|w| w.saturating_sub(2));
                 let nested_lines =
-                    render_block_to_lines(nested_block, highlighter, theme, nested_width);
+                    render_block_to_lines(nested_block, highlighter, theme, nested_width, fences);
                 for nested_line in nested_lines {
                     let mut spans = vec![Span::raw("  ")];
                     spans.extend(nested_line.spans);
@@ -2472,7 +2562,7 @@ fn render_block_to_lines(
                     // Reduce width by indent (2 spaces)
                     let nested_width = available_width.map(|w| w.saturating_sub(2));
                     let nested_lines =
-                        render_block_to_lines(nested, highlighter, theme, nested_width);
+                        render_block_to_lines(nested, highlighter, theme, nested_width, fences);
                     for nested_line in nested_lines {
                         let mut spans = vec![Span::raw("  ")];
                         spans.extend(nested_line.spans);
@@ -2500,7 +2590,8 @@ fn render_block_to_lines(
             for nested in blocks {
                 // Reduce width by blockquote prefix (2 chars)
                 let nested_width = available_width.map(|w| w.saturating_sub(2));
-                let nested_lines = render_block_to_lines(nested, highlighter, theme, nested_width);
+                let nested_lines =
+                    render_block_to_lines(nested, highlighter, theme, nested_width, fences);
                 for nested_line in nested_lines {
                     let mut spans = vec![Span::styled(
                         "│ ",
@@ -2720,6 +2811,136 @@ pub(crate) fn format_inline_markdown<'a>(text: &str, theme: &Theme) -> Vec<Span<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------- code block fences and background ----------
+
+    use crate::tui::syntax::CodeBlockBackground;
+
+    fn code_lines(fences: CodeFences, bg: CodeBlockBackground, lang: Option<&str>) -> Vec<String> {
+        let hl = SyntaxHighlighter::new("base16-ocean.dark", None, bg);
+        let theme = Theme::ocean_dark();
+        render_code_block(lang, "let x = 1;\n", &hl, &theme, false, fences, Some(30))
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn code_fences_full_keeps_both_rows() {
+        let lines = code_lines(CodeFences::Full, CodeBlockBackground::Off, Some("rust"));
+        assert_eq!(lines, vec!["```rust", "let x = 1;", "```"]);
+    }
+
+    #[test]
+    fn code_fences_label_replaces_opening_row_and_drops_closing() {
+        // The language stays visible on its own row, but the block is not
+        // closed off underneath.
+        let lines = code_lines(CodeFences::Label, CodeBlockBackground::Off, Some("rust"));
+        assert_eq!(lines, vec!["rust", "let x = 1;"]);
+    }
+
+    #[test]
+    fn code_fences_label_omits_the_row_entirely_without_a_language() {
+        // No language means no label worth showing, so no blank row either.
+        let lines = code_lines(CodeFences::Label, CodeBlockBackground::Off, None);
+        assert_eq!(lines, vec!["let x = 1;"]);
+    }
+
+    #[test]
+    fn code_fences_none_drops_both_rows() {
+        let lines = code_lines(CodeFences::None, CodeBlockBackground::Off, Some("rust"));
+        assert_eq!(lines, vec!["let x = 1;"]);
+    }
+
+    #[test]
+    fn code_block_background_pads_every_row_to_a_rectangle() {
+        let hl = SyntaxHighlighter::new("base16-ocean.dark", None, CodeBlockBackground::FromTheme);
+        let theme = Theme::ocean_dark();
+        let lines = render_code_block(
+            Some("rust"),
+            "let x = 1;\nlet yy = 22;\n",
+            &hl,
+            &theme,
+            false,
+            CodeFences::Full,
+            Some(30),
+        );
+
+        for line in &lines {
+            let width: usize = line
+                .spans
+                .iter()
+                .map(|s| unicode_width::UnicodeWidthStr::width(s.content.as_ref()))
+                .sum();
+            assert_eq!(width, 30, "row not padded to the block width: {line:?}");
+            for span in &line.spans {
+                assert!(span.style.bg.is_some(), "unpainted span: {span:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn code_block_background_off_leaves_rows_unpainted_and_unpadded() {
+        let lines = {
+            let hl = SyntaxHighlighter::new("base16-ocean.dark", None, CodeBlockBackground::Off);
+            let theme = Theme::ocean_dark();
+            render_code_block(
+                Some("rust"),
+                "let x = 1;\n",
+                &hl,
+                &theme,
+                false,
+                CodeFences::Full,
+                Some(30),
+            )
+        };
+        for line in &lines {
+            for span in &line.spans {
+                assert!(span.style.bg.is_none(), "unexpected background: {span:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn code_block_background_explicit_color_overrides_the_theme() {
+        let want = Color::Rgb(40, 40, 50);
+        let hl =
+            SyntaxHighlighter::new("base16-ocean.dark", None, CodeBlockBackground::Color(want));
+        assert_eq!(hl.code_block_bg(), Some(want));
+    }
+
+    #[test]
+    fn code_block_background_defaults_to_the_code_theme() {
+        // base16-ocean.dark defines a background; it should be used rather than
+        // left unpainted.
+        let hl = SyntaxHighlighter::new("base16-ocean.dark", None, CodeBlockBackground::FromTheme);
+        assert!(hl.code_block_bg().is_some());
+    }
+
+    #[test]
+    fn selection_indicator_keeps_its_own_colors_over_the_block_background() {
+        let hl = SyntaxHighlighter::new("base16-ocean.dark", None, CodeBlockBackground::FromTheme);
+        let theme = Theme::ocean_dark();
+        let lines = render_code_block(
+            Some("rust"),
+            "let x = 1;\n",
+            &hl,
+            &theme,
+            true,
+            CodeFences::Full,
+            Some(30),
+        );
+        let first = &lines[0].spans[0];
+        assert_eq!(first.content.as_ref(), "→ ");
+        assert_eq!(first.style.bg, Some(theme.selection_indicator_bg));
+    }
 
     #[test]
     fn callout_marker_basic_kinds() {

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -2412,13 +2412,11 @@ fn render_code_block(
         )]));
     }
 
-    if let Some(bg) = highlighter.code_block_bg() {
-        let width = available_width.map(usize::from).unwrap_or(0);
-        fill_block_background(&mut lines, bg, width);
-    }
-
-    // Added after the fill so the indicator keeps its own colors and the
-    // padding math above is not thrown off by its width.
+    // Added before the fill so its width counts toward the first row's total.
+    // Appending it afterwards pushed that row past the block width, and with
+    // wrapping on that overflow became a stray sliver row under the fence.
+    // `fill_block_background` leaves spans that already carry a background
+    // alone, so the indicator keeps its own colors either way.
     if selected && let Some(first) = lines.first_mut() {
         first.spans.insert(
             0,
@@ -2430,6 +2428,11 @@ fn render_code_block(
                     .add_modifier(Modifier::BOLD),
             ),
         );
+    }
+
+    if let Some(bg) = highlighter.code_block_bg() {
+        let width = available_width.map(usize::from).unwrap_or(0);
+        fill_block_background(&mut lines, bg, width);
     }
 
     lines
@@ -2940,6 +2943,41 @@ mod tests {
         let first = &lines[0].spans[0];
         assert_eq!(first.content.as_ref(), "→ ");
         assert_eq!(first.style.bg, Some(theme.selection_indicator_bg));
+    }
+
+    #[test]
+    fn selected_code_block_rows_stay_within_the_block_width() {
+        // The indicator has to fit inside the block width, not extend past it.
+        // With wrapping on, a row 2 cells too wide sheds its trailing padding
+        // onto a stray sliver row underneath.
+        let hl = SyntaxHighlighter::new("base16-ocean.dark", None, CodeBlockBackground::FromTheme);
+        let theme = Theme::ocean_dark();
+        let width: u16 = 30;
+
+        for selected in [false, true] {
+            let lines = render_code_block(
+                Some("rust"),
+                "let x = 1;\n",
+                &hl,
+                &theme,
+                selected,
+                CodeFences::Full,
+                Some(width),
+            );
+            let logical = lines.len();
+            for line in &lines {
+                let row: usize = line
+                    .spans
+                    .iter()
+                    .map(|s| unicode_width::UnicodeWidthStr::width(s.content.as_ref()))
+                    .sum();
+                assert_eq!(row, usize::from(width), "selected={selected}: {line:?}");
+            }
+            let rendered = Paragraph::new(Text::from(lines))
+                .wrap(Wrap { trim: false })
+                .line_count(width);
+            assert_eq!(rendered, logical, "selected={selected}: block wrapped");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Resolves #75.

Two commits: the first extracts a shared `render_code_block` helper with no behavior change, the second builds the feature on it.

## Why

The top-level and nested renderers each had their own copy of the fence/highlight/fence sequence, so any fence change had to be written twice. And @marsavic's diagnosis in #75 was exactly right: `code_fence` only colors the fence markers, `inline_code_bg` only applies to inline spans, and `src/tui/syntax.rs` built every span from `style.foreground` while ignoring `theme.settings.background` — so a code theme could not supply a block background either.

## What

`[content] code_fences` takes three values:

| Value | Result |
|-------|--------|
| `full` | Both fence rows, as today |
| `label` | A dim language name above the block, no closing row |
| `none` | No fence rows |

Rows are dropped rather than hidden, so they cost no vertical space. The label sits on its own row rather than on the first line of code — @marsavic's point that an inline tag would get caught in mouse and terminal selection. A block with no language gets no label row at all.

`[theme] code_block_bg` defaults to the code theme's own background so it agrees with the syntax colors, and covers the full block width including padding. `code_block_bg = "none"` turns it off.

## Note on the default

Painting the background changes the default appearance for existing users. That is what #75 asks for, and syntect themes define a background precisely so code renders on it, but it is a visible change rather than a pure opt-in. `"none"` is there so anyone who prefers the old look can get it back.

## Verification

The extraction commit was checked by dumping rendered `Text` for a document with top-level, callout-nested, and details-nested code blocks plus a mermaid block, in both selected and unselected states. All 98 rendered lines matched before and after.

11 new tests cover each fence mode, the no-language label case, rectangle padding to exact width, background off, explicit color override, theme-derived default, and the selection indicator keeping its own colors over the block background. Full suite passes (394), with clippy `-D warnings` clean on default, `--no-default-features`, and `--all-features`.

## Unrelated observation

While testing I noticed a code block inside a callout renders *above* its `▌ ℹ` header rather than within it. That predates this branch (it reproduces on `main`) and I have left it alone. Worth its own issue if you want it chased.