### PR TITLE
deps: turbovault-parser 2.0.0, fixing callouts and four image forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **turbovault-parser 1.6.0 to 2.0.0**, which is where all five fixes above come from. See its [2.0.0 notes](https://github.com/Epistates/turbovault/blob/main/CHANGELOG.md) for the full list
 - **An image in a list item now renders in place as text rather than as a picture.** Until now the parser hoisted it out to the top level, where it drew as a full image detached from the list it belonged to. It stays in the item now, and the list renderer has no inline image support, so it draws as its markdown. `.img` and `stats` report it correctly either way
-- **A fenced block inside a callout renders as literal text rather than highlighted code**, and is no longer selectable in interactive mode. It used to escape the quote and render as a real code block above the callout header. Inside the quote it is drawn from the callout's raw content
+- **A fenced block inside a callout renders as verbatim text rather than highlighted code**, and is no longer selectable in interactive mode. It used to escape the quote and render as a real code block above the callout header. Inside the quote it is drawn from the callout's raw content, with the fence rows kept intact rather than being read as inline-code delimiters
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Images wrapped in a link reach `.img` and `stats`.** `[![badge](b.png)](https://ci.example)` was dropped outright, so a README badge row reported zero images
 - **Image titles are their own field.** `![a](x.png "Title")` put `x.png "Title"` into `.src` and left `.title` empty, rather than splitting the two. A destination containing spaces keeps both
 - **List item images are reported the same tight or loose.** A list item's images now come from its inline run, so whether a blank line sits between items no longer changes what `.img` returns, and the item keeps its own text
+- **A callout holding a fenced block scrolls to the right offset.** A callout is drawn from the blockquote's raw content, one row per line, but its height was measured from its nested blocks, which counts a fenced block as three rows rather than the five it draws. Reachable only once the parser stopped hoisting that block out of the quote, so it arrived with the upgrade
 
 ### Changed
 
 - **turbovault-parser 1.6.0 to 2.0.0**, which is where all five fixes above come from. See its [2.0.0 notes](https://github.com/Epistates/turbovault/blob/main/CHANGELOG.md) for the full list
+- **An image in a list item now renders in place as text rather than as a picture.** Until now the parser hoisted it out to the top level, where it drew as a full image detached from the list it belonged to. It stays in the item now, and the list renderer has no inline image support, so it draws as its markdown. `.img` and `stats` report it correctly either way
+- **A fenced block inside a callout renders as literal text rather than highlighted code**, and is no longer selectable in interactive mode. It used to escape the quote and render as a real code block above the callout header. Inside the quote it is drawn from the callout's raw content
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Multi-line callouts no longer collapse into their title.** `> [!NOTE] Heads up` followed by more quoted lines rendered as `▌ ℹ Heads upSome text.More text.`, because the parser joined a blockquote's body lines with no separator and the callout renderer takes the first line as its marker. Every callout longer than one line was affected
+- **Code blocks inside a callout render inside it.** A fenced block in a blockquote was emitted as a top-level sibling ahead of the quote, so it appeared above the `▌ ℹ` header instead of within the callout
+- **Images wrapped in a link reach `.img` and `stats`.** `[![badge](b.png)](https://ci.example)` was dropped outright, so a README badge row reported zero images
+- **Image titles are their own field.** `![a](x.png "Title")` put `x.png "Title"` into `.src` and left `.title` empty, rather than splitting the two. A destination containing spaces keeps both
+- **List item images are reported the same tight or loose.** A list item's images now come from its inline run, so whether a blank line sits between items no longer changes what `.img` returns, and the item keeps its own text
+
+### Changed
+
+- **turbovault-parser 1.6.0 to 2.0.0**, which is where all five fixes above come from. See its [2.0.0 notes](https://github.com/Epistates/turbovault/blob/main/CHANGELOG.md) for the full list
+
+### Known issues
+
+- **Images and links inside a blockquote lose their destination.** `> ![a](a.png)` is not reported by `.img`. A blockquote is rebuilt from its raw text and re-parsed, and that pass flattens inline elements to plain text. 1.6.0 masked this by also hoisting a copy of the image out of the quote, which 2.0.0 correctly stopped doing. Tracked at [turbovault#68](https://github.com/Epistates/turbovault/issues/68)
+
 ## [0.7.0] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Image titles are their own field.** `![a](x.png "Title")` put `x.png "Title"` into `.src` and left `.title` empty, rather than splitting the two. A destination containing spaces keeps both
 - **List item images are reported the same tight or loose.** A list item's images now come from its inline run, so whether a blank line sits between items no longer changes what `.img` returns, and the item keeps its own text
 - **A callout holding a fenced block scrolls to the right offset.** A callout is drawn from the blockquote's raw content, one row per line, but its height was measured from its nested blocks, which counts a fenced block as three rows rather than the five it draws. Reachable only once the parser stopped hoisting that block out of the quote, so it arrived with the upgrade
+- **An image in a multi-block list item is reported once, not twice.** A list item's inline run already carries every image in the item, including those inside its nested blocks, so collecting from both reported each one twice. `- item` followed by an indented `![a](a.png)` returned two entries from `.img` and counted two in `stats`
 
 ### Changed
 
@@ -24,7 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Known issues
 
-- **Images and links inside a blockquote lose their destination.** `> ![a](a.png)` is not reported by `.img`. A blockquote is rebuilt from its raw text and re-parsed, and that pass flattens inline elements to plain text. 1.6.0 masked this by also hoisting a copy of the image out of the quote, which 2.0.0 correctly stopped doing. Tracked at [turbovault#68](https://github.com/Epistates/turbovault/issues/68)
+All tracked at [turbovault#68](https://github.com/Epistates/turbovault/issues/68), and all in the parser rather than here:
+
+- **Images and links inside a blockquote lose their destination.** `> ![a](a.png)` is not reported by `.img`. A blockquote is rebuilt from its raw text and re-parsed, and that pass flattens inline elements to plain text. 1.6.0 masked this by also hoisting a copy of the image out of the quote, which 2.0.0 correctly stopped doing
+- **A fenced block inside a blockquote reports `start_line` and `end_line` as `0`**, because the quote fragment is re-parsed from line zero. Any `.code | select(.start_line > N)` filter treats it as sitting before the document starts
+- **An image in a heading loses its alt text**, and that text is appended to the heading instead: `# Title ![a](a.png)` reports `.h1` as `Title a` and gives the image an empty `alt`. The `src` is correct. This one predates 2.0.0
 
 ## [0.7.0] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **turbovault-parser 1.6.0 to 2.0.0**, which is where all five fixes above come from. See its [2.0.0 notes](https://github.com/Epistates/turbovault/blob/main/CHANGELOG.md) for the full list
-- **An image in a list item now renders in place as text rather than as a picture.** Until now the parser hoisted it out to the top level, where it drew as a full image detached from the list it belonged to. It stays in the item now, and the list renderer has no inline image support, so it draws as its markdown. `.img` and `stats` report it correctly either way
+- **An image in a list item no longer draws in the TUI.** Until now the parser hoisted it out to the top level, where it drew as a full image detached from the list it belonged to. It stays in the item now, and the list renderer has no inline image support, so nothing draws it and it is no longer selectable. `.img`, `stats` and every other query report it correctly. Tracked at [#87](https://github.com/Epistates/treemd/issues/87)
 - **A fenced block inside a callout renders as verbatim text rather than highlighted code**, and is no longer selectable in interactive mode. It used to escape the quote and render as a real code block above the callout header. Inside the quote it is drawn from the callout's raw content, with the fence rows kept intact rather than being read as inline-code delimiters
 
 ### Known issues

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,8 +2782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2935,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "turbovault-core"
-version = "1.6.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c68b413757ee3845f5b5182c8643e16430de683af4588d005ed2f9b21f84be"
+checksum = "ed17e0bae0b8f54779233525f04372a6e1a738253f83263d4f7cbe67225619ff"
 dependencies = [
  "chrono",
  "log",
@@ -2955,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "turbovault-parser"
-version = "1.6.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c153db2ca08515d7bfb1b2c31479710f41d39f0c0e1ddfe75d2abc32cd9c37fa"
+checksum = "dbe3322bbbc01c31935ba554b20a0830606517c1e1fa0ca5e2746762b69b7f41"
 dependencies = [
  "log",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ ureq = "3"
 unicode-width = "0.2"
 
 # Turbovault integration - OFM parsing with code-block awareness
-turbovault-parser = "1.6.0"
+turbovault-parser = "2.0.0"
 
 # Serialization for JSON output
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/QUERY_LANGUAGE.md
+++ b/docs/QUERY_LANGUAGE.md
@@ -89,15 +89,19 @@ To search bodies, use `.code | select(contains("TODO"))`.
 | `.frontmatter` | YAML front matter |
 
 `.img` finds images written standalone, inline in a sentence, in a heading,
-wrapped in a link, and in a list item whether the list is tight or loose. One
-case is still missed because of how the underlying parser reports it:
+wrapped in a link, and in a list item whether the list is tight or loose. Two
+cases are still wrong because of how the underlying parser reports them, both
+tracked at [turbovault#68](https://github.com/Epistates/turbovault/issues/68):
 
-- **Images inside a blockquote**: `> ![a](a.png)` is not reported. A blockquote
-  is rebuilt from its raw text and re-parsed, and that pass flattens inline
-  elements to plain text, so the image survives only as its alt and the source
-  is gone before treemd sees the block. Links inside a blockquote lose their
-  destination the same way. Tracked at
-  [turbovault#68](https://github.com/Epistates/turbovault/issues/68).
+- **Images inside a blockquote** are not reported at all. `> ![a](a.png)`
+  returns nothing. A blockquote is rebuilt from its raw text and re-parsed, and
+  that pass flattens inline elements to plain text, so the source is gone
+  before treemd sees the block. Links inside a blockquote lose their
+  destination the same way, and a fenced block inside one reports
+  `start_line` and `end_line` as `0`.
+- **An image in a heading loses its alt text**, and that text is appended to
+  the heading instead. `# Title ![a](a.png)` gives `.img` an `alt` of `""` and
+  reports `.h1` as `Title a`. The `src` is correct.
 
 ### Document
 

--- a/docs/QUERY_LANGUAGE.md
+++ b/docs/QUERY_LANGUAGE.md
@@ -88,16 +88,16 @@ To search bodies, use `.code | select(contains("TODO"))`.
 | `.para` | All paragraphs |
 | `.frontmatter` | YAML front matter |
 
-`.img` finds images written standalone, inline in a sentence, in a heading, in
-a blockquote, and in a tight list item. Three cases are still missed because of
-how the underlying parser reports them:
+`.img` finds images written standalone, inline in a sentence, in a heading,
+wrapped in a link, and in a list item whether the list is tight or loose. One
+case is still missed because of how the underlying parser reports it:
 
-- **Images wrapped in a link**: `[![badge](b.png)](https://ci.example)` is not
-  reported, so README badge rows come back empty and `stats` undercounts.
-- **Loose list items** (items separated by blank lines) do not expose their
-  content as blocks, so images inside them are missed.
-- **Image titles**: `![a](x.png "Title")` puts `x.png "Title"` in `.src` and
-  leaves `.title` empty, rather than splitting the two.
+- **Images inside a blockquote**: `> ![a](a.png)` is not reported. A blockquote
+  is rebuilt from its raw text and re-parsed, and that pass flattens inline
+  elements to plain text, so the image survives only as its alt and the source
+  is gone before treemd sees the block. Links inside a blockquote lose their
+  destination the same way. Tracked at
+  [turbovault#68](https://github.com/Epistates/turbovault/issues/68).
 
 ### Document
 
@@ -253,9 +253,9 @@ fails with `Expected ')', found ','`. Pipe each branch separately instead:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `.src` | string | Image source URL (includes the title when one is present) |
+| `.src` | string | Image source URL |
 | `.alt` | string | Alt text |
-| `.title` | string? | Title attribute, currently always empty |
+| `.title` | string? | Title attribute, `null` when the image has none |
 
 Access these as properties (`.img[0].alt`). Only `src`/`url`/`href` exist as
 pipe functions; `.img | alt` reports `Unknown function`.

--- a/src/query/eval.rs
+++ b/src/query/eval.rs
@@ -845,10 +845,14 @@ struct ExtractedBlocks {
 
 /// Collects images carried as inline elements rather than standalone blocks.
 ///
-/// Nearly every image is one of these: a standalone `![alt](src)` line is a
-/// paragraph in CommonMark, so without this the most common form would never
-/// reach `.img` or `stats`. Headings and list items carry theirs the same way,
-/// which is why all three call this rather than relying on `Block::Image`.
+/// A standalone `![alt](src)` line is a paragraph in CommonMark, so without
+/// this the most common form of image would never reach `.img` or `stats`.
+/// List items carry theirs the same way.
+///
+/// Headings do not, despite the arm below that calls this for them: the parser
+/// still hoists a heading's image out to a top-level `Block::Image`, so that
+/// arm is what actually reports it. Both paths are needed, and neither is
+/// redundant. See [`Images`] for why the list arm must not do both.
 fn collect_inline_images(inline: &[InlineElement], out: &mut ExtractedBlocks) {
     for element in inline {
         if let InlineElement::Image {
@@ -874,10 +878,21 @@ fn extract_blocks(doc: &Document) -> ExtractedBlocks {
 
     let mut out = ExtractedBlocks::default();
 
+    /// Whether a `walk` pass should collect images.
+    ///
+    /// A list item's `inline` already carries every image in the item, at any
+    /// depth, so the pass over that item's nested blocks has to leave images
+    /// alone. Collecting from both counts each one twice.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Images {
+        Collect,
+        Skip,
+    }
+
     // Recursively extract blocks from nested structures (e.g., list items,
     // blockquotes, details). Top-level paragraphs/blockquotes are collected by
     // the outer loop; nested ones are collected here too.
-    fn walk(blocks: &[Block], out: &mut ExtractedBlocks) {
+    fn walk(blocks: &[Block], out: &mut ExtractedBlocks, images: Images) {
         for block in blocks {
             match block {
                 Block::Code {
@@ -893,7 +908,7 @@ fn extract_blocks(doc: &Document) -> ExtractedBlocks {
                         end_line: *end_line,
                     });
                 }
-                Block::Image { alt, src, title } => {
+                Block::Image { alt, src, title } if images == Images::Collect => {
                     out.images.push(ImageValue {
                         alt: alt.clone(),
                         src: src.clone(),
@@ -915,18 +930,24 @@ fn extract_blocks(doc: &Document) -> ExtractedBlocks {
                     });
                 }
                 Block::Paragraph { content, inline } => {
-                    collect_inline_images(inline, out);
+                    if images == Images::Collect {
+                        collect_inline_images(inline, out);
+                    }
                     out.paragraphs.push(ParagraphValue {
                         content: content.clone(),
                     });
                 }
                 Block::Heading { inline, .. } => {
-                    collect_inline_images(inline, out);
+                    if images == Images::Collect {
+                        collect_inline_images(inline, out);
+                    }
                 }
                 Block::List { ordered, items } => {
                     for item in items {
-                        collect_inline_images(&item.inline, out);
-                        walk(&item.blocks, out);
+                        if images == Images::Collect {
+                            collect_inline_images(&item.inline, out);
+                        }
+                        walk(&item.blocks, out, Images::Skip);
                     }
                     out.lists.push(ListValue {
                         ordered: *ordered,
@@ -943,17 +964,17 @@ fn extract_blocks(doc: &Document) -> ExtractedBlocks {
                     out.blockquotes.push(BlockquoteValue {
                         content: content.clone(),
                     });
-                    walk(blocks, out);
+                    walk(blocks, out, images);
                 }
                 Block::Details { blocks, .. } => {
-                    walk(blocks, out);
+                    walk(blocks, out, images);
                 }
                 _ => {}
             }
         }
     }
 
-    walk(&blocks, &mut out);
+    walk(&blocks, &mut out, Images::Collect);
 
     out.links = links
         .into_iter()
@@ -1501,6 +1522,40 @@ fn main() {}
         // Guards the block and inline paths from both claiming one image.
         assert_eq!(image_srcs("- item ![a](a.png)").len(), 1);
         assert_eq!(image_srcs("![a](a.png)").len(), 1);
+    }
+
+    /// A list item's `inline` carries every image in the item, including the
+    /// ones inside its nested blocks, so walking those blocks as well reports
+    /// each of them twice. Only multi-block items expose this: in a one-block
+    /// item there is nothing for the walk to find, which is why the single
+    /// paragraph cases above stayed green while `.img` was returning doubles.
+    #[test]
+    fn test_images_in_a_multi_block_list_item_are_reported_once() {
+        assert_eq!(image_srcs("- item\n\n  ![a](a.png)\n"), ["a.png"]);
+        assert_eq!(image_srcs("- [ ] task\n\n  ![t](t.png)\n"), ["t.png"]);
+        assert_eq!(
+            image_srcs("- item ![z](z.png)\n\n  more ![y](y.png)\n"),
+            ["z.png", "y.png"],
+            "an item's own image and its nested one, each once and in order"
+        );
+        assert_eq!(
+            image_srcs("- a ![1](1.png)\n\n  b ![2](2.png)\n\n  c ![3](3.png)\n"),
+            ["1.png", "2.png", "3.png"]
+        );
+        assert_eq!(
+            image_srcs("- item\n\n  ```rust\n  code\n  ```\n\n  ![c](c.png)\n"),
+            ["c.png"],
+            "a fenced block between the text and the image changes nothing"
+        );
+    }
+
+    /// Suppressing images while walking a list item's nested blocks must not
+    /// suppress anything else those blocks carry.
+    #[test]
+    fn test_nested_blocks_in_a_list_item_still_yield_non_image_content() {
+        let md = "- item\n\n  ```rust\n  code\n  ```\n\n  | a | b |\n  |---|---|\n  | 1 | 2 |\n";
+        assert_eq!(eval(md, ".code").len(), 1);
+        assert_eq!(eval(md, ".table").len(), 1);
     }
 
     /// The image forms that turbovault-parser 2.0.0 fixed. Each returned

--- a/src/query/eval.rs
+++ b/src/query/eval.rs
@@ -845,10 +845,10 @@ struct ExtractedBlocks {
 
 /// Collects images carried as inline elements rather than standalone blocks.
 ///
-/// The parser only emits a top-level `Block::Image` when an image is not
-/// wrapped in a paragraph — which in practice means tight list items. A
-/// standalone `![alt](src)` line is a paragraph in CommonMark, so without this
-/// the most common form of image would never reach `.img` or `stats`.
+/// Nearly every image is one of these: a standalone `![alt](src)` line is a
+/// paragraph in CommonMark, so without this the most common form would never
+/// reach `.img` or `stats`. Headings and list items carry theirs the same way,
+/// which is why all three call this rather than relying on `Block::Image`.
 fn collect_inline_images(inline: &[InlineElement], out: &mut ExtractedBlocks) {
     for element in inline {
         if let InlineElement::Image {
@@ -925,6 +925,7 @@ fn extract_blocks(doc: &Document) -> ExtractedBlocks {
                 }
                 Block::List { ordered, items } => {
                     for item in items {
+                        collect_inline_images(&item.inline, out);
                         walk(&item.blocks, out);
                     }
                     out.lists.push(ListValue {
@@ -1475,15 +1476,23 @@ fn main() {}
         assert_eq!(image_srcs("![a](a.png)"), ["a.png"]);
         assert_eq!(image_srcs("# T\n\n![a](a.png)"), ["a.png"]);
         assert_eq!(image_srcs("Text with ![a](a.png) inside."), ["a.png"]);
-        assert_eq!(image_srcs("> ![a](a.png)"), ["a.png"]);
         assert_eq!(image_srcs("# Title ![a](a.png)"), ["a.png"]);
-        // Tight list items are the one case the parser reports as a block.
         assert_eq!(image_srcs("- item ![a](a.png)"), ["a.png"]);
+    }
+
+    /// A blockquote is rebuilt from its raw text and re-parsed, and that pass
+    /// flattens every inline element to plain text, so an image inside one
+    /// survives as its alt text with the source discarded. Not recoverable
+    /// here: the destination is gone before we receive the block.
+    /// Tracked upstream at Epistates/turbovault#68.
+    #[test]
+    fn test_images_inside_a_blockquote_are_a_known_upstream_gap() {
+        assert_eq!(image_srcs("> ![a](a.png)"), Vec::<String>::new());
     }
 
     #[test]
     fn test_multiple_images_are_collected_in_document_order() {
-        let md = "![a](a.png)\n\n![b](b.png)\n\n> ![c](c.png)";
+        let md = "![a](a.png)\n\n![b](b.png)\n\n- item ![c](c.png)";
         assert_eq!(image_srcs(md), ["a.png", "b.png", "c.png"]);
     }
 
@@ -1492,6 +1501,44 @@ fn main() {}
         // Guards the block and inline paths from both claiming one image.
         assert_eq!(image_srcs("- item ![a](a.png)").len(), 1);
         assert_eq!(image_srcs("![a](a.png)").len(), 1);
+    }
+
+    /// The image forms that turbovault-parser 2.0.0 fixed. Each returned
+    /// nothing usable on 1.6.0: the linked image was dropped outright, the
+    /// title was folded into the source, and a list item reported differently
+    /// depending only on whether a blank line sat between the items.
+    #[test]
+    fn test_image_forms_fixed_in_parser_2_0() {
+        let details = |md: &str| -> Vec<(String, String, Option<String>)> {
+            eval(md, ".img")
+                .into_iter()
+                .filter_map(|v| match v {
+                    Value::Image(i) => Some((i.alt, i.src, i.title)),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        assert_eq!(
+            details("[![badge](b.png)](https://ci.example)"),
+            [("badge".into(), "b.png".into(), None)],
+            "an image wrapped in a link is still an image"
+        );
+        assert_eq!(
+            details(r#"![a](x.png "Title")"#),
+            [("a".into(), "x.png".into(), Some("Title".into()))],
+            "the title is its own field, not part of the source"
+        );
+        assert_eq!(
+            details(r#"![a](my image.png "Title")"#),
+            [("a".into(), "my image.png".into(), Some("Title".into()))],
+            "a spaced destination keeps both its source and its title"
+        );
+        assert_eq!(
+            image_srcs("- item ![a](a.png)\n\n- second ![b](b.png)"),
+            ["a.png", "b.png"],
+            "a loose list reports the same images as a tight one"
+        );
     }
 
     #[test]

--- a/src/tui/interactive.rs
+++ b/src/tui/interactive.rs
@@ -1298,24 +1298,19 @@ mod interactive_tests {
         );
         let mermaid_rows = std::collections::HashMap::new();
 
-        let Some(block @ Block::Blockquote { content, .. }) = blocks.first() else {
+        let Some(block) = blocks.first() else {
             panic!("expected a blockquote, got {:?}", blocks);
         };
-
         let Block::Blockquote { blocks: nested, .. } = block else {
-            unreachable!()
+            panic!("expected a blockquote, got {:?}", block);
         };
-        assert_ne!(
-            count_block_lines(nested, &mermaid_rows),
-            content.lines().count(),
-            "this case stops guarding anything once the two agree by accident"
-        );
 
-        assert_eq!(
-            count_single_block_lines(block, &mermaid_rows),
-            content.lines().count(),
-            "counted height must match the rows the callout renderer emits"
-        );
+        // The callout draws six rows: the `[!NOTE] Hi` header, `Text.`, the
+        // blank separator, and the three rows of the fence. Counting the
+        // nested blocks instead gives four, one for the paragraph and three
+        // for the code block, which is the undercount this guards.
+        assert_eq!(count_single_block_lines(block, &mermaid_rows), 6);
+        assert_eq!(count_block_lines(nested, &mermaid_rows), 4);
     }
 
     /// A blockquote that is not a callout still renders its nested blocks, so

--- a/src/tui/interactive.rs
+++ b/src/tui/interactive.rs
@@ -1265,7 +1265,13 @@ fn count_single_block_lines(
             2 + content.lines().count()
         }
         Block::List { items, .. } => items.len(),
-        Block::Blockquote { blocks, .. } => count_block_lines(blocks, mermaid_rows),
+        // A callout draws one row per line of `content` and ignores its nested
+        // blocks, so counting those instead would undercount every callout
+        // holding a fenced block.
+        Block::Blockquote { content, blocks } => {
+            crate::tui::ui::rendered_callout_line_count(content)
+                .unwrap_or_else(|| count_block_lines(blocks, mermaid_rows))
+        }
         Block::Table { rows, .. } => 4 + rows.len(),
         Block::Image { .. } => BLOCK_IMAGE_TOTAL_LINES,
         Block::HorizontalRule => 1,
@@ -1277,6 +1283,57 @@ fn count_single_block_lines(
 mod interactive_tests {
     use super::*;
     use crate::parser::content::parse_content;
+
+    /// A callout is drawn from the blockquote's raw `content`, one row per
+    /// line, so its height has to be counted the same way. Counting its nested
+    /// blocks instead undercounts every callout holding a fenced block, which
+    /// scrolls the viewport to the wrong offset. turbovault-parser 2.0.0 made
+    /// this reachable by keeping a fenced block inside the quote that 1.6.0
+    /// had been hoisting out to the top level.
+    #[test]
+    fn a_callout_is_counted_by_what_the_renderer_draws() {
+        let blocks = parse_content(
+            "> [!NOTE] Hi\n> Text.\n>\n> ```rust\n> fn main() {}\n> ```\n",
+            0,
+        );
+        let mermaid_rows = std::collections::HashMap::new();
+
+        let Some(block @ Block::Blockquote { content, .. }) = blocks.first() else {
+            panic!("expected a blockquote, got {:?}", blocks);
+        };
+
+        let Block::Blockquote { blocks: nested, .. } = block else {
+            unreachable!()
+        };
+        assert_ne!(
+            count_block_lines(nested, &mermaid_rows),
+            content.lines().count(),
+            "this case stops guarding anything once the two agree by accident"
+        );
+
+        assert_eq!(
+            count_single_block_lines(block, &mermaid_rows),
+            content.lines().count(),
+            "counted height must match the rows the callout renderer emits"
+        );
+    }
+
+    /// A blockquote that is not a callout still renders its nested blocks, so
+    /// it must still be counted from those.
+    #[test]
+    fn a_plain_blockquote_is_still_counted_from_its_nested_blocks() {
+        let blocks = parse_content("> just a quote\n", 0);
+        let mermaid_rows = std::collections::HashMap::new();
+
+        let Some(block @ Block::Blockquote { blocks: nested, .. }) = blocks.first() else {
+            panic!("expected a blockquote, got {:?}", blocks);
+        };
+
+        assert_eq!(
+            count_single_block_lines(block, &mermaid_rows),
+            count_block_lines(nested, &mermaid_rows)
+        );
+    }
 
     #[test]
     fn test_nested_code_blocks_in_list_items() {

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -2289,6 +2289,19 @@ fn callout_decoration(kind: &str, theme: &Theme) -> (&'static str, Color) {
     }
 }
 
+/// How many rows `render_callout_lines` draws for `content`, or `None` when
+/// `content` is not a callout.
+///
+/// A callout is rendered from the blockquote's raw `content`, one row per
+/// line, and its nested blocks are never rendered separately. Anything that
+/// needs to predict the height of a blockquote has to ask here rather than
+/// counting nested blocks, or it will disagree with what is drawn and the
+/// viewport will scroll to the wrong offset.
+pub(crate) fn rendered_callout_line_count(content: &str) -> Option<usize> {
+    parse_callout_marker(content.lines().next()?)?;
+    Some(content.lines().count())
+}
+
 /// Render a blockquote as a styled callout if its first line carries a
 /// callout marker. Returns None when the blockquote is not a callout.
 fn render_callout_lines(content: &str, theme: &Theme) -> Option<Vec<Line<'static>>> {
@@ -3173,6 +3186,35 @@ mod tests {
         );
         assert!(row(1).contains("Some text."));
         assert!(row(2).contains("More text."));
+    }
+
+    /// `rendered_callout_line_count` is what the interactive line counter
+    /// trusts to predict a callout's height. If it ever drifts from what the
+    /// renderer emits, the viewport scrolls to the wrong offset, so pin the
+    /// two together rather than trusting them to stay in step.
+    #[test]
+    fn rendered_callout_line_count_matches_the_rows_drawn() {
+        let theme = Theme::ocean_dark();
+        for content in [
+            "[!NOTE] Hi",
+            "[!NOTE] Hi\nText.",
+            "[!NOTE] Hi\nText.\n\n```rust\nfn main() {}\n```",
+            "[!warning]- Folded\nbody\nmore body",
+        ] {
+            let drawn = render_callout_lines(content, &theme).unwrap().len();
+            assert_eq!(
+                rendered_callout_line_count(content),
+                Some(drawn),
+                "predicted height disagrees with the render of {:?}",
+                content
+            );
+        }
+    }
+
+    #[test]
+    fn rendered_callout_line_count_declines_a_plain_quote() {
+        assert_eq!(rendered_callout_line_count("just a quote"), None);
+        assert_eq!(rendered_callout_line_count(""), None);
     }
 
     /// A fenced block inside a callout used to be emitted as a top-level

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -3144,4 +3144,57 @@ mod tests {
         let theme = Theme::ocean_dark();
         assert!(render_callout_lines("just a quote", &theme).is_none());
     }
+
+    /// Feeds real parser output rather than a hand-written string. The
+    /// hand-written tests above passed throughout the period when every
+    /// multi-line callout rendered its whole body inside the title, because
+    /// the parser was joining the lines before we ever saw them.
+    #[test]
+    fn a_parsed_multi_line_callout_keeps_its_body_out_of_the_title() {
+        use crate::parser::content::parse_content;
+        use crate::parser::output::Block;
+
+        let blocks = parse_content("> [!NOTE] Heads up\n> Some text.\n> More text.\n", 1);
+        let Some(Block::Blockquote { content, .. }) = blocks.first() else {
+            panic!("expected a blockquote, got {:?}", blocks);
+        };
+
+        let theme = Theme::ocean_dark();
+        let lines = render_callout_lines(content, &theme).unwrap();
+        let row =
+            |i: usize| -> String { lines[i].spans.iter().map(|s| s.content.as_ref()).collect() };
+
+        assert_eq!(lines.len(), 3, "header plus one row per body line");
+        assert!(row(0).contains("Heads up"));
+        assert!(
+            !row(0).contains("Some text."),
+            "body leaked into the title: {:?}",
+            row(0)
+        );
+        assert!(row(1).contains("Some text."));
+        assert!(row(2).contains("More text."));
+    }
+
+    /// A fenced block inside a callout used to be emitted as a top-level
+    /// sibling ahead of the quote, so it rendered above the callout header.
+    #[test]
+    fn a_fenced_block_inside_a_callout_stays_inside_it() {
+        use crate::parser::content::parse_content;
+        use crate::parser::output::Block;
+
+        let blocks = parse_content(
+            "> [!NOTE] Hi\n> Text.\n>\n> ```rust\n> fn main() {}\n> ```\n",
+            1,
+        );
+
+        assert_eq!(blocks.len(), 1, "code escaped the quote: {:?}", blocks);
+        let Some(Block::Blockquote { blocks: inner, .. }) = blocks.first() else {
+            panic!("expected a blockquote, got {:?}", blocks);
+        };
+        assert!(
+            inner.iter().any(|b| matches!(b, Block::Code { .. })),
+            "code block is not inside the quote: {:?}",
+            inner
+        );
+    }
 }

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -2318,9 +2318,23 @@ fn render_callout_lines(content: &str, theme: &Theme) -> Option<Vec<Line<'static
         ),
     ])];
 
+    // A fenced block reaches us as raw text, so its rows must not go through
+    // the inline formatter: that reads the three backticks as inline-code
+    // delimiters, swallowing the fence and leaving a bare styled word where
+    // the opening row was. Inside a fence the text is code, so it is emitted
+    // verbatim.
+    let mut in_fence = false;
     for line in content_lines {
         let mut spans = vec![bar()];
-        spans.extend(format_inline_markdown(line, theme));
+        let is_fence = line.trim_start().starts_with("```");
+        if is_fence || in_fence {
+            spans.push(Span::styled(line.to_string(), theme.inline_code_style()));
+        } else {
+            spans.extend(format_inline_markdown(line, theme));
+        }
+        if is_fence {
+            in_fence = !in_fence;
+        }
         lines.push(Line::from(spans));
     }
 
@@ -3215,6 +3229,47 @@ mod tests {
     fn rendered_callout_line_count_declines_a_plain_quote() {
         assert_eq!(rendered_callout_line_count("just a quote"), None);
         assert_eq!(rendered_callout_line_count(""), None);
+    }
+
+    /// The inline formatter reads three backticks as an inline-code
+    /// delimiter, so running a fence row through it swallows the fence and
+    /// leaves a bare styled `rust` where ```` ```rust ```` was written.
+    #[test]
+    fn a_fence_inside_a_callout_survives_the_inline_formatter() {
+        let theme = Theme::ocean_dark();
+        let lines = render_callout_lines("[!NOTE] Hi\nText.\n\n```rust\nfn main() {}\n```", &theme)
+            .unwrap();
+        let row =
+            |i: usize| -> String { lines[i].spans.iter().map(|s| s.content.as_ref()).collect() };
+
+        assert_eq!(lines.len(), 6);
+        assert!(
+            row(3).contains("```rust"),
+            "opening fence lost: {:?}",
+            row(3)
+        );
+        assert!(row(4).contains("fn main() {}"));
+        assert!(row(5).contains("```"), "closing fence lost: {:?}", row(5));
+    }
+
+    /// Text after a closing fence is prose again, not code.
+    #[test]
+    fn a_callout_leaves_the_fence_when_it_closes() {
+        let theme = Theme::ocean_dark();
+        let lines =
+            render_callout_lines("[!NOTE] Hi\n```\ncode\n```\nafter `x` here", &theme).unwrap();
+        assert_eq!(lines.len(), 5, "header, two fences, code, trailing prose");
+        let after = &lines[4];
+        assert!(
+            after.spans.iter().any(|s| s.content.contains("after ")),
+            "trailing prose was treated as code: {:?}",
+            after
+        );
+        assert!(
+            after.spans.iter().all(|s| !s.content.contains('`')),
+            "inline code was not formatted after the fence closed: {:?}",
+            after
+        );
     }
 
     /// A fenced block inside a callout used to be emitted as a top-level


### PR DESCRIPTION
Picks up the five defects reported from here as Epistates/turbovault#55.

Multi-line callouts rendered their whole body inside the title, because the parser joined a blockquote's body lines with no separator and `render_callout_lines` takes the first line as its marker. A fenced block inside a callout was emitted as a top-level sibling ahead of the quote, so it drew above the header. Linked images were dropped outright, image titles were folded into `.src`, and a list item reported different images depending only on whether a blank line sat between the items.

One change was needed on this side. A list item's images used to arrive as a hoisted top-level `Block::Image`, so `walk` found them through `item.blocks`. They now sit in `item.inline`, which is where the walk reads them from. The callout renderer already split on line breaks, so it started working the moment the parser stopped joining them.

The blockquote tests here were asserting hand-written strings rather than parser output, which is why they stayed green for the entire period every multi-line callout was broken. The two new ones parse real markdown.

Known gap, filed as Epistates/turbovault#68: a blockquote is rebuilt from raw text and re-parsed, and that pass flattens inline elements to plain text, so an image or link inside one loses its destination. 1.6.0 masked this by also hoisting a copy of the image out of the quote, which 2.0.0 correctly stopped doing. `docs/QUERY_LANGUAGE.md` records it and a test pins the current behavior so it cannot regress unnoticed.

Resolves #79
Resolves #80
